### PR TITLE
Visibility of the namespaces 

### DIFF
--- a/GeomSharp/Extensions/Collections.cs
+++ b/GeomSharp/Extensions/Collections.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace GeomSharp {
+namespace GeomSharp.Extensions {
 
-  public static class Extensions {
+  public static class Collections {
     /// <summary>
     /// Purely a helper function for other routines. Calling (publicly) a sum of points makes no sense
     /// </summary>

--- a/GeomSharp/Extensions/Comparison3D.cs
+++ b/GeomSharp/Extensions/Comparison3D.cs
@@ -1,4 +1,4 @@
-﻿namespace GeomSharp.Comparison {
+﻿namespace GeomSharp.Extensions {
 
   public static class Comparison3D {
     public static bool IsPerpendicular(this Plane plane,

--- a/GeomSharp/Extensions/Intersection2D.cs
+++ b/GeomSharp/Extensions/Intersection2D.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using GeomSharp.Overlap;
-
-namespace GeomSharp.Intersection {
+namespace GeomSharp.Extensions {
 
   public static class Intersection2D {
     // intersection functions among different objects

--- a/GeomSharp/Extensions/Intersection3D.cs
+++ b/GeomSharp/Extensions/Intersection3D.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using GeomSharp.Overlap;
-
-namespace GeomSharp.Intersection {
+namespace GeomSharp.Extensions {
 
   public static class Intersection3D {
     // intersection functions among different objects

--- a/GeomSharp/Extensions/Overlap2D.cs
+++ b/GeomSharp/Extensions/Overlap2D.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace GeomSharp.Overlap {
+namespace GeomSharp.Extensions {
 
   public static class Overlap2D {
     // intersection functions among different objects

--- a/GeomSharp/Extensions/Overlap3D.cs
+++ b/GeomSharp/Extensions/Overlap3D.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using GeomSharp.Intersection;
-
-namespace GeomSharp.Overlap {
+namespace GeomSharp.Extensions {
 
   public static class Overlap3D {
     // intersection functions among different objects

--- a/GeomSharp/GeomSharp.csproj
+++ b/GeomSharp/GeomSharp.csproj
@@ -44,46 +44,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Algebra\Extensions.cs" />
-    <Compile Include="Angle.cs" />
-    <Compile Include="Extensions\Comparison3D.cs" />
-    <Compile Include="Constants.cs" />
-    <Compile Include="Exceptions.cs" />
-    <Compile Include="Extensions\Collections.cs" />
-    <Compile Include="Extensions\Intersection2D.cs" />
-    <Compile Include="Extensions\Intersection3D.cs" />
-    <Compile Include="IntersectionResult.cs" />
-    <Compile Include="Line2D.cs" />
-    <Compile Include="Line3D.cs" />
-    <Compile Include="LineSegment2D.cs" />
-    <Compile Include="LineSegment3D.cs" />
-    <Compile Include="NullValue.cs" />
-    <Compile Include="Extensions\Overlap2D.cs" />
-    <Compile Include="Extensions\Overlap3D.cs" />
-    <Compile Include="Plane.cs" />
-    <Compile Include="Point2D.cs" />
-    <Compile Include="Point3D.cs" />
-    <Compile Include="LineSegmentSet2D.cs" />
-    <Compile Include="LineSegmentSet3D.cs" />
-    <Compile Include="PointSet3D.cs" />
-    <Compile Include="PointSet2D.cs" />
-    <Compile Include="Polygon2D.cs" />
-    <Compile Include="Polygon3D.cs" />
-    <Compile Include="Polyline2D.cs" />
-    <Compile Include="Polyline3D.cs" />
-    <Compile Include="ProjectionResult.cs" />
-    <Compile Include="Ray2D.cs" />
-    <Compile Include="Ray3D.cs" />
-    <Compile Include="Transformation\Shift2D.cs" />
-    <Compile Include="Transformation\Shift3D.cs" />
-    <Compile Include="Transformation\Rotation3D.cs" />
-    <Compile Include="Transformation\Rotation2D.cs" />
-    <Compile Include="Triangle2D.cs" />
-    <Compile Include="Triangle3D.cs" />
-    <Compile Include="Algebra\Matrix.cs" />
-    <Compile Include="Algebra\Vector.cs" />
-    <Compile Include="Vector2D.cs" />
-    <Compile Include="Vector3D.cs" />
+    <Compile Include="Algebra\*.cs" />
+    <Compile Include="*.cs" />
+    <Compile Include="Extensions\*.cs" />
+    <Compile Include="Transformation\*.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/GeomSharp/GeomSharp.csproj
+++ b/GeomSharp/GeomSharp.csproj
@@ -46,20 +46,20 @@
   <ItemGroup>
     <Compile Include="Algebra\Extensions.cs" />
     <Compile Include="Angle.cs" />
-    <Compile Include="Comparison\Comparison3D.cs" />
+    <Compile Include="Extensions\Comparison3D.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Exceptions.cs" />
-    <Compile Include="Extensions.cs" />
-    <Compile Include="Intersection\Intersection2D.cs" />
-    <Compile Include="Intersection\Intersection3D.cs" />
+    <Compile Include="Extensions\Collections.cs" />
+    <Compile Include="Extensions\Intersection2D.cs" />
+    <Compile Include="Extensions\Intersection3D.cs" />
     <Compile Include="IntersectionResult.cs" />
     <Compile Include="Line2D.cs" />
     <Compile Include="Line3D.cs" />
     <Compile Include="LineSegment2D.cs" />
     <Compile Include="LineSegment3D.cs" />
     <Compile Include="NullValue.cs" />
-    <Compile Include="Overlap\Overlap2D.cs" />
-    <Compile Include="Overlap\Overlap3D.cs" />
+    <Compile Include="Extensions\Overlap2D.cs" />
+    <Compile Include="Extensions\Overlap3D.cs" />
     <Compile Include="Plane.cs" />
     <Compile Include="Point2D.cs" />
     <Compile Include="Point3D.cs" />

--- a/GeomSharp/GeomSharp.nuspec
+++ b/GeomSharp/GeomSharp.nuspec
@@ -4,7 +4,7 @@
     <!-- Identifier that must be unique within the hosting gallery -->
     <id>GeomSharp</id>
     <!-- Package version number that is used when resolving dependencies -->
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     <!-- Authors contain text that appears directly on the gallery -->
     <authors>Angelo Mastroberardino</authors>
     <!-- 

--- a/GeomSharp/GeomSharp.nuspec
+++ b/GeomSharp/GeomSharp.nuspec
@@ -4,7 +4,7 @@
     <!-- Identifier that must be unique within the hosting gallery -->
     <id>GeomSharp</id>
     <!-- Package version number that is used when resolving dependencies -->
-    <version>1.0.13</version>
+    <version>1.0.14</version>
     <!-- Authors contain text that appears directly on the gallery -->
     <authors>Angelo Mastroberardino</authors>
     <!-- 
@@ -27,7 +27,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <!-- Any details about this particular release -->
     <releaseNotes>
-      - upped the version to republish
+      - refactored the extensions module
     </releaseNotes>
     <!-- 
             The description can be used in package manager UI. Note that the

--- a/GeomSharp/GeomSharp.nuspec
+++ b/GeomSharp/GeomSharp.nuspec
@@ -18,6 +18,8 @@
     <license type="expression">MIT</license>
     <!-- Icon is used in Visual Studio's package manager UI -->
     <icon>icon.png</icon>
+    <!-- readme file: does not work -->
+    <!-- <readme>README.md</readme> -->  
     <!-- 
             If true, this value prompts the user to accept the license when
             installing the package. 
@@ -26,6 +28,7 @@
     <!-- Any details about this particular release -->
     <releaseNotes>
       - deployment script bugfix
+      - visibility of the nested GeomSharp namespaces (.Extensions, .Algebra, .Transformation)
       - fixed outstanding issues with Area and CenterOfMass and wrote Tests, 
       - added Rotation/Shift, 
       - refactored extension modules, 
@@ -54,6 +57,7 @@
     <file src="..\etc\overlap.png" target="etc\" />
     <file src="..\etc\test_run.png" target="etc\" />
     <file src="etc\icon.png" target="" />
+    <file src="etc\readme.txt" target="" />   <!--remove if MD works-->
     
     <file src="bin\Release\*.dll" target="lib/net48" /> <!-- nuget pack seems unable copy this DLL, here explicitely copied -->
     <file src="bin\Release\*.pdb" target="lib/net48" />

--- a/GeomSharp/Line3D.cs
+++ b/GeomSharp/Line3D.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
 
-using GeomSharp.Comparison;
+using GeomSharp.Extensions;
 
 namespace GeomSharp {
   /// <summary>

--- a/GeomSharp/LineSegment2D.cs
+++ b/GeomSharp/LineSegment2D.cs
@@ -124,13 +124,6 @@ namespace GeomSharp {
             ? throw new Exception("LocationPct called with Point2D that does not belong to the line")
             : Math.Round(P0.DistanceTo(point) / Length(), decimal_precision);
 
-    // all extensions here
-    public IntersectionResult Intersection(Polygon2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
-        Extensions.Intersection2D.Intersection(this, other, decimal_precision);
-
-    public bool Intersects(Polygon2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
-        Extensions.Intersection2D.Intersects(this, other, decimal_precision);
-
     /// <summary>
     /// Tells whether two line segments intersect.
     /// First the parallelism is tested. Then the crossing. Then, the intersection point being contained inside both

--- a/GeomSharp/LineSegment2D.cs
+++ b/GeomSharp/LineSegment2D.cs
@@ -123,6 +123,13 @@ namespace GeomSharp {
             ? throw new Exception("LocationPct called with Point2D that does not belong to the line")
             : Math.Round(P0.DistanceTo(point) / Length(), decimal_precision);
 
+    // all extensions here
+    public IntersectionResult Intersection(Polygon2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
+        Extensions.Intersection2D.Intersection(this, other, decimal_precision);
+
+    public bool Intersects(Polygon2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
+        Extensions.Intersection2D.Intersects(this, other, decimal_precision);
+
     /// <summary>
     /// Tells whether two line segments intersect.
     /// First the parallelism is tested. Then the crossing. Then, the intersection point being contained inside both

--- a/GeomSharp/PointSet2D.cs
+++ b/GeomSharp/PointSet2D.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
 
+using GeomSharp.Extensions;
+
 namespace GeomSharp {
 
   /// <summary>

--- a/GeomSharp/PointSet3D.cs
+++ b/GeomSharp/PointSet3D.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
 
+using GeomSharp.Extensions;
+
 namespace GeomSharp {
 
   /// <summary>

--- a/GeomSharp/Polygon2D.cs
+++ b/GeomSharp/Polygon2D.cs
@@ -226,13 +226,6 @@ namespace GeomSharp {
       throw new NotImplementedException("triangulation not implemented yet");
     }
 
-    // all extensions here
-    public IntersectionResult Intersection(LineSegment2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
-        Extensions.Intersection2D.Intersection(this, other, decimal_precision);
-
-    public bool Intersects(LineSegment2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
-        Extensions.Intersection2D.Intersects(this, other, decimal_precision);
-
     // its own intersection functions
 
     public bool Intersects(Polygon2D other, int decimal_precision = Constants.THREE_DECIMALS) =>

--- a/GeomSharp/Polygon2D.cs
+++ b/GeomSharp/Polygon2D.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
 
-using GeomSharp.Algebra;
+using GeomSharp.Extensions;
 
 namespace GeomSharp {
 
@@ -221,6 +221,15 @@ namespace GeomSharp {
 
       throw new NotImplementedException("triangulation not implemented yet");
     }
+
+    // all extensions here
+    public IntersectionResult Intersection(LineSegment2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
+        Extensions.Intersection2D.Intersection(this, other, decimal_precision);
+
+    public bool Intersects(LineSegment2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
+        Extensions.Intersection2D.Intersects(this, other, decimal_precision);
+
+    // its own intersection functions
 
     public bool Intersects(Polygon2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);

--- a/GeomSharp/Polygon3D.cs
+++ b/GeomSharp/Polygon3D.cs
@@ -7,7 +7,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
 
 using GeomSharp.Algebra;
-using GeomSharp.Intersection;
+using GeomSharp.Extensions;
 
 namespace GeomSharp {
 

--- a/GeomSharp/Polyline2D.cs
+++ b/GeomSharp/Polyline2D.cs
@@ -6,8 +6,7 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
 
-using GeomSharp.Intersection;
-using System.ComponentModel;
+using GeomSharp.Extensions;
 
 namespace GeomSharp {
   /// <summary>

--- a/GeomSharp/Polyline3D.cs
+++ b/GeomSharp/Polyline3D.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
 
-using GeomSharp.Intersection;
+using GeomSharp.Extensions;
 
 namespace GeomSharp {
   /// <summary>

--- a/GeomSharp/Triangle2D.cs
+++ b/GeomSharp/Triangle2D.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
 
-using GeomSharp.Intersection;
+using GeomSharp.Extensions;
 
 namespace GeomSharp {
 

--- a/GeomSharp/Triangle3D.cs
+++ b/GeomSharp/Triangle3D.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
 
-using GeomSharp.Overlap;
+using GeomSharp.Extensions;
 
 namespace GeomSharp {
 

--- a/GeomSharpTests/ExtensionsTests.cs
+++ b/GeomSharpTests/ExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// internal
 using GeomSharp;
+using GeomSharp.Extensions;
 
 // external
 using System;

--- a/GeomSharpTests/IntersectionExtensions2DTests.cs
+++ b/GeomSharpTests/IntersectionExtensions2DTests.cs
@@ -1,6 +1,6 @@
 ﻿// internal
 using GeomSharp;
-using GeomSharp.Intersection;
+using GeomSharp.Extensions;
 
 // external
 using System;

--- a/GeomSharpTests/IntersectionExtensions3DTests.cs
+++ b/GeomSharpTests/IntersectionExtensions3DTests.cs
@@ -1,6 +1,6 @@
 ﻿// internal
 using GeomSharp;
-using GeomSharp.Intersection;
+using GeomSharp.Extensions;
 
 // external
 using System;

--- a/GeomSharpTests/OverlapExtensions2DTests.cs
+++ b/GeomSharpTests/OverlapExtensions2DTests.cs
@@ -1,6 +1,6 @@
 ﻿// internal
 using GeomSharp;
-using GeomSharp.Overlap;
+using GeomSharp.Extensions;
 
 // external
 using System;

--- a/GeomSharpTests/OverlapExtensions3DTests.cs
+++ b/GeomSharpTests/OverlapExtensions3DTests.cs
@@ -1,7 +1,6 @@
 ﻿// internal
 using GeomSharp;
-using GeomSharp.Intersection;
-using GeomSharp.Overlap;
+using GeomSharp.Extensions;
 
 // external
 using System;

--- a/GeomSharpTests/PlaneTests.cs
+++ b/GeomSharpTests/PlaneTests.cs
@@ -1,6 +1,6 @@
 ﻿// internal
 using GeomSharp;
-using GeomSharp.Comparison;
+using GeomSharp.Extensions;
 
 // external
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/GeomSharpTests/Polyline2DTests.cs
+++ b/GeomSharpTests/Polyline2DTests.cs
@@ -1,6 +1,6 @@
 ﻿// internal
 using GeomSharp;
-using GeomSharp.Intersection;
+using GeomSharp.Extensions;
 
 // external
 using System.Collections.Generic;

--- a/GeomSharpTests/Polyline3DTests.cs
+++ b/GeomSharpTests/Polyline3DTests.cs
@@ -1,6 +1,6 @@
 ﻿// internal
 using GeomSharp;
-using GeomSharp.Intersection;
+using GeomSharp.Extensions;
 
 // external
 using System.Collections.Generic;

--- a/deploy_to_nuget.ps1
+++ b/deploy_to_nuget.ps1
@@ -29,13 +29,13 @@ Write-Host "id = $xml_id"
 $xml_version = $xmlElm.package.metadata.version
 Write-Host "version = $xml_version"
 
-nuget pack $pkg_spec_path -Build -Symbols -Properties Configuration=Release -OutputDirectory $pkg_out_dir -IncludeReferencedProjects
+nuget pack $pkg_spec_path -Build -Symbols -Properties Configuration=Release -OutputDirectory $pkg_out_dir -IncludeReferencedProjects 
 
-# $pkg_out_file = $(Join-Path $pkg_out_dir $xml_id.$xml_version.nupkg)
-# Write-Host "package = $(ls $pkg_out_file)"
+# $pkg_out_file = $(Join-Path $pkg_out_dir "$xml_id.$xml_version.nupkg")
+# Write-Host "package = $pkg_out_file"
 #nuget push $pkg_out_file -Source $target_repo -SkipDuplicate
 
-$pkg_out_sym = $(Join-Path $pkg_out_dir $xml_id.$xml_version.symbols.nupkg)
-Write-Host "package w/symbols = $(ls $pkg_out_sym)"
+$pkg_out_sym = $(Join-Path $pkg_out_dir "$xml_id.$xml_version.symbols.nupkg")
+Write-Host "package w/symbols = $pkg_out_sym"
 
 nuget push $pkg_out_sym -Source $target_repo -SymbolSource $target_repo -SkipDuplicate


### PR DESCRIPTION
Visibility of the namespaces as in #21 

When added as a Refernce (to a local DLL), all namespaces are accessible (GeomSharp, GeomSharp.Extensions, .Transformation, .Algebra).
When added from Nuget, only the main namespace (GeomSharp) is accessible.

Also trying to fix a push script at merge. #20 