### PR TITLE
fixed the bug of LocationPct, changed function name

### DIFF
--- a/GeomSharp/Constants.cs
+++ b/GeomSharp/Constants.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GeomSharp {
   public static class Constants {

--- a/GeomSharp/LineSegmentSet2D.cs
+++ b/GeomSharp/LineSegmentSet2D.cs
@@ -27,7 +27,7 @@ namespace GeomSharp {
             seg_hashmap.Add(key, i);
           }
         }
-        Items = new List<LineSegment2D>(seg_hashmap.Select(pair => segments[pair.Value]));
+        Items = new List<LineSegment2D>(seg_hashmap.OrderBy(p => p.Value).Select(pair => segments[pair.Value]));
       }
 
       Size = Items.Count;

--- a/GeomSharp/LineSegmentSet3D.cs
+++ b/GeomSharp/LineSegmentSet3D.cs
@@ -27,7 +27,7 @@ namespace GeomSharp {
             seg_hashmap.Add(key, i);
           }
         }
-        Items = new List<LineSegment3D>(seg_hashmap.Select(pair => segments[pair.Value]));
+        Items = new List<LineSegment3D>(seg_hashmap.OrderBy(p => p.Value).Select(pair => segments[pair.Value]));
       }
 
       Size = Items.Count;

--- a/GeomSharp/Polyline2D.cs
+++ b/GeomSharp/Polyline2D.cs
@@ -333,18 +333,19 @@ namespace GeomSharp {
     /// Returns the relative position of a point onto a curve in % [0,1]
     /// Returns double.MaxValue and warns an error if the point does not belong to the curve at all
     /// It's in 3D, and works on a linearized version of the curve
-    /// It's the twin function of GetPointOnPolyline
+    /// It's the twin function of GetPoint
     /// </summary>
     /// <param name="point"></param>
     /// <param name="decimal_precision"></param>
     /// <returns></returns>
-    public double LocationPct(Point2D point, int decimal_precision = Constants.THREE_DECIMALS) {
+    public double GetPct(Point2D point, int decimal_precision = Constants.THREE_DECIMALS) {
       double curve_len = Length();
       double len_done = 0;
+
       foreach (var piece_line in ToSegments(decimal_precision)) {
         double piece_len = piece_line.Length();
         if (piece_line.Contains(point, decimal_precision)) {
-          double t = Math.Round(piece_line.P0.DistanceTo(point) / Length(), decimal_precision);
+          double t = Math.Round(piece_line.P0.DistanceTo(point) / piece_line.Length(), decimal_precision);
           if (t >= 0 && t <= 1) {
             return (len_done + t * piece_len) / curve_len;
           }
@@ -362,23 +363,23 @@ namespace GeomSharp {
     /// Gives a warning and returns null in case of errors
     /// It's the twin function of LocationAlongTheLine
     /// </summary>
-    /// <param name="pct">must be in the range [0, 1] of throws</param>
+    /// <param name="pct_location">must be in the range [0, 1] of throws</param>
     /// <param name="decimal_precision"></param>
     /// <returns></returns>
-    public Point2D GetPointOnPolyline(double pct, int decimal_precision = Constants.THREE_DECIMALS) {
-      if (Math.Round(pct, decimal_precision) < 0 || Math.Round(pct, decimal_precision) > 1) {
+    public Point2D GetPoint(double pct_location, int decimal_precision = Constants.THREE_DECIMALS) {
+      if (Math.Round(pct_location, decimal_precision) < 0 || Math.Round(pct_location, decimal_precision) > 1) {
         throw new ArgumentException("pct should be in the range [0,1]");
       }
 
       double curve_len = Math.Round(Length(), decimal_precision);
-      double curve_todo = Math.Round(pct * curve_len, decimal_precision);
+      double curve_todo = Math.Round(pct_location * curve_len, decimal_precision);
       double len_done = 0;
       double pct_done = 0;
       foreach (var piece_line in ToSegments(decimal_precision)) {
         double piece_len = piece_line.Length();
         if (Math.Round(len_done + piece_len, decimal_precision) >= curve_todo) {
           // found segment containing the point
-          double tI = ((pct - pct_done) * curve_len) / piece_len;
+          double tI = ((pct_location - pct_done) * curve_len) / piece_len;
           var PI = piece_line.P0 + tI * (piece_line.P1 - piece_line.P0);
           return PI;
         }
@@ -386,7 +387,7 @@ namespace GeomSharp {
         pct_done = len_done / curve_len;
       }
 
-      // string.Format("GetPointOnPolyline did not find the point on the curve for {0:F4}%", pct)
+      // string.Format("GetPoint did not find the point on the curve for {0:F4}%", pct)
       return null;
     }
   }

--- a/GeomSharp/Polyline3D.cs
+++ b/GeomSharp/Polyline3D.cs
@@ -369,18 +369,19 @@ namespace GeomSharp {
     /// Returns the relative position of a point onto a curve in % [0,1]
     /// Returns double.MaxValue and warns an error if the point does not belong to the curve at all
     /// It's in 3D, and works on a linearized version of the curve
-    /// It's the twin function of GetPointOnPolyline
+    /// It's the twin function of GetPoint
     /// </summary>
     /// <param name="point"></param>
     /// <param name="decimal_precision"></param>
     /// <returns></returns>
-    public double LocationPct(Point3D point, int decimal_precision = Constants.THREE_DECIMALS) {
+    public double GetPct(Point3D point, int decimal_precision = Constants.THREE_DECIMALS) {
       double curve_len = Length();
       double len_done = 0;
+
       foreach (var piece_line in ToSegments(decimal_precision)) {
         double piece_len = piece_line.Length();
         if (piece_line.Contains(point, decimal_precision)) {
-          double t = Math.Round(piece_line.P0.DistanceTo(point) / Length(), decimal_precision);
+          double t = Math.Round(piece_line.P0.DistanceTo(point) / piece_line.Length(), decimal_precision);
           if (t >= 0 && t <= 1) {
             return (len_done + t * piece_len) / curve_len;
           }
@@ -398,23 +399,23 @@ namespace GeomSharp {
     /// Gives a warning and returns null in case of errors
     /// It's the twin function of LocationAlongTheLine
     /// </summary>
-    /// <param name="pct">must be in the range [0, 1] of throws</param>
+    /// <param name="pct_location">must be in the range [0, 1] of throws</param>
     /// <param name="decimal_precision"></param>
     /// <returns></returns>
-    public Point3D GetPointOnPolyline(double pct, int decimal_precision = Constants.THREE_DECIMALS) {
-      if (Math.Round(pct, decimal_precision) < 0 || Math.Round(pct, decimal_precision) > 1) {
+    public Point3D GetPoint(double pct_location, int decimal_precision = Constants.THREE_DECIMALS) {
+      if (Math.Round(pct_location, decimal_precision) < 0 || Math.Round(pct_location, decimal_precision) > 1) {
         throw new ArgumentException("pct should be in the range [0,1]");
       }
 
       double curve_len = Math.Round(Length(), decimal_precision);
-      double curve_todo = Math.Round(pct * curve_len, decimal_precision);
+      double curve_todo = Math.Round(pct_location * curve_len, decimal_precision);
       double len_done = 0;
       double pct_done = 0;
       foreach (var piece_line in ToSegments(decimal_precision)) {
         double piece_len = piece_line.Length();
         if (Math.Round(len_done + piece_len, decimal_precision) >= curve_todo) {
           // found segment containing the point
-          double tI = ((pct - pct_done) * curve_len) / piece_len;
+          double tI = ((pct_location - pct_done) * curve_len) / piece_len;
           var PI = piece_line.P0 + tI * (piece_line.P1 - piece_line.P0);
           return PI;
         }

--- a/GeomSharpTests/Polyline2DTests.cs
+++ b/GeomSharpTests/Polyline2DTests.cs
@@ -1,7 +1,6 @@
 ﻿// internal
 using GeomSharp;
 
-
 // external
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -117,6 +116,38 @@ namespace GeomSharpTests {
         Assert.IsFalse(pline.Intersects(seg),
                        "segment parallel to the polyline's vertices do not intersect (vertex " + i.ToString() +
                            "), \n\tpline=" + pline.ToWkt() + "\n\tseg=" + seg.ToWkt());
+      }
+    }
+
+    [RepeatedTestMethod(100)]
+    public void GetPoint() {
+      // 2D
+      (var pline, var pline_direction, int n) = RandomGenerator.MakeSimplePolyline2D();
+
+      // Console.WriteLine("t = " + t.ToWkt());
+      if (pline is null) {
+        return;
+      }
+
+      foreach (int decimal_precision in new List<int> { 0, 1, 2, Constants.THREE_DECIMALS, Constants.NINE_DECIMALS }) {
+        // test location pct
+        var loc_pct = pline.Select(p => pline.GetPct(p, decimal_precision)).ToList();
+        Assert.AreEqual(pline.Size, loc_pct.Count, "polyline size != location points size");
+        Assert.IsTrue(Math.Round(loc_pct.First(), decimal_precision) == 0, $"pct (0) is not 0%");
+        for (int i = 0; i < loc_pct.Count - 1; ++i) {
+          Assert.IsTrue(Math.Round(loc_pct[i] - loc_pct[i + 1], decimal_precision) < 0,
+                        $"pct {i} is not smaller than pct {i + 1}");
+        }
+        Assert.IsTrue(Math.Round(loc_pct.Last(), decimal_precision) == 1, $"pct (n) is not 100%");
+
+        // test equality with original points
+        var pts_on_pct_loc = loc_pct.Select(pct => pline.GetPoint(pct, decimal_precision)).ToList();
+        Assert.AreEqual(pline.Size, pts_on_pct_loc.Count, "polyline size != pts_on_pct_loc points size");
+        for (int i = 0; i < pts_on_pct_loc.Count; ++i) {
+          Assert.IsTrue(
+              pline[i].AlmostEquals(pts_on_pct_loc[i], decimal_precision),
+              $"pline point {i} -> {pline[i].ToWkt(decimal_precision)} is not equal to pont on polyline than pct {Math.Round(100 * loc_pct[i], decimal_precision)}%, {pts_on_pct_loc[i].ToWkt(decimal_precision)}");
+        }
       }
     }
   }

--- a/GeomSharpTests/Polyline3DTests.cs
+++ b/GeomSharpTests/Polyline3DTests.cs
@@ -1,7 +1,6 @@
 ﻿// internal
 using GeomSharp;
 
-
 // external
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -118,6 +117,38 @@ namespace GeomSharpTests {
         Assert.IsFalse(pline.Intersects(seg),
                        "segment parallel to the polyline's vertices do not intersect (vertex " + i.ToString() +
                            "), \n\tpline=" + pline.ToWkt() + "\n\tseg=" + seg.ToWkt());
+      }
+    }
+
+    [RepeatedTestMethod(100)]
+    public void GetPoint() {
+      // 2D
+      (var pline, var long_vec, var lat_vec, int n) = RandomGenerator.MakeSimplePolyline3D();
+
+      // Console.WriteLine("t = " + t.ToWkt());
+      if (pline is null) {
+        return;
+      }
+
+      foreach (int decimal_precision in new List<int> { 0, 1, 2, Constants.THREE_DECIMALS, Constants.NINE_DECIMALS }) {
+        // test location pct
+        var loc_pct = pline.Select(p => pline.GetPct(p, decimal_precision)).ToList();
+        Assert.AreEqual(pline.Size, loc_pct.Count, "polyline size != location points size");
+        Assert.IsTrue(Math.Round(loc_pct.First(), decimal_precision) == 0, $"pct (0) is not 0%");
+        for (int i = 0; i < loc_pct.Count - 1; ++i) {
+          Assert.IsTrue(Math.Round(loc_pct[i] - loc_pct[i + 1], decimal_precision) < 0,
+                        $"pct {i} is not smaller than pct {i + 1}");
+        }
+        Assert.IsTrue(Math.Round(loc_pct.Last(), decimal_precision) == 1, $"pct (n) is not 100%");
+
+        // test equality with original points
+        var pts_on_pct_loc = loc_pct.Select(pct => pline.GetPoint(pct, decimal_precision)).ToList();
+        Assert.AreEqual(pline.Size, pts_on_pct_loc.Count, "polyline size != pts_on_pct_loc points size");
+        for (int i = 0; i < pts_on_pct_loc.Count; ++i) {
+          Assert.IsTrue(
+              pline[i].AlmostEquals(pts_on_pct_loc[i], decimal_precision),
+              $"pline point {i} -> {pline[i].ToWkt(decimal_precision)} is not equal to pont on polyline than pct {Math.Round(100 * loc_pct[i], decimal_precision)}%, {pts_on_pct_loc[i].ToWkt(decimal_precision)}");
+        }
       }
     }
   }


### PR DESCRIPTION
* bugfix
bad 
```
double t = Math.Round(piece_line.P0.DistanceTo(point) / Length(), decimal_precision);
```
replaced with
```
double t = Math.Round(piece_line.P0.DistanceTo(point) / piece_line.Length(), decimal_precision);
```

* changed the function names from
From 
```
public Point3D GetPointOnPolyline(double pct_location, int decimal_precision = Constants.THREE_DECIMALS);
public double LocationPct(Point3D point, int decimal_precision = Constants.THREE_DECIMALS);
```
To
```
public Point3D GetPoint(double pct_location, int decimal_precision = Constants.THREE_DECIMALS);
public double GetPct(Point3D point, int decimal_precision = Constants.THREE_DECIMALS);
```

* Added two tests (`location %` and `get point(%)`) on both 2D and 3D polylines