### PR TITLE
Bugfix/line intersections

### DIFF
--- a/GeomSharp/Line2D.cs
+++ b/GeomSharp/Line2D.cs
@@ -3,7 +3,6 @@
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
-using System.Text;
 
 namespace GeomSharp {
   /// <summary>
@@ -137,21 +136,18 @@ namespace GeomSharp {
       return !IsParallel(other, decimal_precision);  // in 2D you only have two chances: parallel or intersecting
     }
     public override IntersectionResult Intersection(Line2D other, int decimal_precision = Constants.THREE_DECIMALS) {
-      if (!Intersects(other, decimal_precision)) {
+      // TODO: can be put this code in a common place, and avoid duplicating it over and over ?
+      var U = P1 - P0;
+      var V = other.P1 - other.P0;
+      var W = P0 - other.P0;
+      double denom = V.PerpProduct(U);
+      if (Math.Round(denom, decimal_precision) == 0) {
         return new IntersectionResult();
       }
 
-      // TODO: can be put this code in a common place, and avoid duplicating it over and over ?
-      var V = other.Direction;
-      var U = Direction;
-      var W = Origin - other.Origin;
+      double sI = -V.PerpProduct(W) / denom;  // guaranteed non-zero if non-parallel
 
-      double sI = -V.PerpProduct(W) / V.PerpProduct(U);  // guaranteed non-zero if non-parallel
-
-      var Ps = Origin + sI * Direction;
-      if (!(Contains(Ps, decimal_precision) && other.Contains(Ps, decimal_precision))) {
-        throw new Exception(String.Format("Intersection({0}) miscalculated Ps", GetType().ToString().ToString()));
-      }
+      var Ps = P0 + sI * U;
 
       return new IntersectionResult(Ps);
     }
@@ -217,7 +213,7 @@ namespace GeomSharp {
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
     public override IntersectionResult Intersection(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var line_inter = Intersection(other.ToLine(), decimal_precision);
-      if (line_inter.ValueType == typeof(NullValue)) {
+      if (line_inter.ValueType != typeof(Point2D)) {
         return new IntersectionResult();
       }
 

--- a/GeomSharp/Line2D.cs
+++ b/GeomSharp/Line2D.cs
@@ -132,9 +132,11 @@ namespace GeomSharp {
         throw new NotImplementedException("");
 
     //  line
-    public override bool Intersects(Line2D other, int decimal_precision = Constants.THREE_DECIMALS) {
-      return !IsParallel(other, decimal_precision);  // in 2D you only have two chances: parallel or intersecting
-    }
+    public override bool Intersects(Line2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
+        Intersection(other, decimal_precision).ValueType != typeof(NullValue);
+    // !IsParallel(other, decimal_precision);
+    // could be quicker in 2D you only have two chances: parallel or intersecting
+
     public override IntersectionResult Intersection(Line2D other, int decimal_precision = Constants.THREE_DECIMALS) {
       // TODO: can be put this code in a common place, and avoid duplicating it over and over ?
       var U = P1 - P0;

--- a/GeomSharp/Line2D.cs
+++ b/GeomSharp/Line2D.cs
@@ -165,6 +165,12 @@ namespace GeomSharp {
     public override IntersectionResult Overlap(Line2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Overlaps(other, decimal_precision) ? new IntersectionResult(this) : new IntersectionResult();
 
+    // ray
+    public override bool Overlaps(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
+        other.Overlaps(this, decimal_precision);
+    public override IntersectionResult Overlap(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
+        other.Overlap(this, decimal_precision);
+
     //  line segment
     public override bool Intersects(LineSegment2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         other.Intersects(this, decimal_precision);
@@ -212,32 +218,9 @@ namespace GeomSharp {
 
     //  ray
     public override bool Intersects(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
-        Intersection(other, decimal_precision).ValueType != typeof(NullValue);
-    public override IntersectionResult Intersection(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) {
-      var line_inter = Intersection(other.ToLine(), decimal_precision);
-      if (line_inter.ValueType != typeof(Point2D)) {
-        return new IntersectionResult();
-      }
-
-      var pI = (Point2D)line_inter.Value;
-      if (!other.Contains(pI, decimal_precision)) {
-        return new IntersectionResult();
-      }
-      return new IntersectionResult(pI);
-    }
-    public override bool Overlaps(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
-        Overlap(other, decimal_precision).ValueType != typeof(NullValue);
-    public override IntersectionResult Overlap(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) {
-      if (!other.Direction.IsParallel(Direction, decimal_precision)) {
-        return new IntersectionResult();
-      }
-
-      if (Contains(other.Origin, decimal_precision)) {
-        return new IntersectionResult(other);
-      }
-
-      return new IntersectionResult();
-    }
+        other.Intersects(this, decimal_precision);
+    public override IntersectionResult Intersection(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
+        other.Intersection(this, decimal_precision);
 
     //  triangle
     public override bool Intersects(Triangle2D other, int decimal_precision = Constants.THREE_DECIMALS) =>

--- a/GeomSharp/Line3D.cs
+++ b/GeomSharp/Line3D.cs
@@ -3,7 +3,6 @@
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
-using Microsoft.SqlServer.Server;
 
 namespace GeomSharp {
   /// <summary>
@@ -159,17 +158,22 @@ namespace GeomSharp {
         return new IntersectionResult();
       }
       // Daniel Sunday's magic
-      var U = Direction;
-      var W = Origin - other.Origin;
+      var U = P1 - P0;
+      var W = P0 - other.Origin;
       var n = other.Normal;
 
-      double sI = -n.DotProduct(W) / n.DotProduct(U);
+      double denom = n.DotProduct(U);
+      if (Math.Round(denom, decimal_precision) == 0) {
+        return new IntersectionResult();
+      }
+
+      double sI = -n.DotProduct(W) / denom;
 
       Point3D q = Origin + sI * U;
 
-      if (!other.Contains(q, decimal_precision)) {
-        throw new Exception("plane.Intersection(Line3D) failed");
-      }
+      // if (!other.Contains(q, decimal_precision)) {
+      //   throw new Exception("plane.Intersection(Line3D) failed");
+      // }
 
       return new IntersectionResult(q);
     }
@@ -202,51 +206,20 @@ namespace GeomSharp {
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
 
     public override IntersectionResult Intersection(Line3D other, int decimal_precision = Constants.THREE_DECIMALS) {
-      if (IsParallel(other, decimal_precision)) {
+      // TODO: can be put this code in a common place, and avoid duplicating it over and over ?
+      var U = P1 - P0;
+      var V = other.P1 - other.P0;
+      var W = P0 - other.P0;
+      double denom = V.PerpProduct(U);
+      if (Math.Round(denom, decimal_precision) == 0) {
         return new IntersectionResult();
       }
 
-      // pick the first plane 2D where both lines can be projected as lines and not as dots
-      // (verify that neither line is perpendicular to the projecting plane)
-      Plane plane_2d =
-          !(this.IsPerpendicular(Plane.XY, decimal_precision) || other.IsPerpendicular(Plane.XY, decimal_precision))
-              ? Plane.XY
-              : (!(this.IsPerpendicular(Plane.YZ, decimal_precision) ||
-                   other.IsPerpendicular(Plane.YZ, decimal_precision))
-                     ? Plane.YZ
-                     : Plane.ZX);
+      double sI = -V.PerpProduct(W) / denom;  // guaranteed non-zero if non-parallel
 
-      (var p1, var other_p1) = (plane_2d.ProjectInto(Origin), plane_2d.ProjectInto(other.Origin));
-      (var p2, var other_p2) =
-          (plane_2d.ProjectInto(Origin + 2 * Direction), plane_2d.ProjectInto(other.Origin + 2 * other.Direction));
-      (var line_2d, var other_line_2d) =
-          (Line2D.FromPoints(p1, p2, decimal_precision), Line2D.FromPoints(other_p1, other_p2, decimal_precision));
+      var Ps = P0 + sI * U;
 
-      var inter_res = line_2d.Intersection(other_line_2d, decimal_precision);
-      if (inter_res.ValueType == typeof(NullValue)) {
-        // no 2D intersection, no 3D intersection either
-        return new IntersectionResult();
-      }
-      // there is a 2D intersection, let's get the respective 3D point
-      var pI_2d = (Point2D)inter_res.Value;
-
-      // given the linear relationship between the 3D line and the projected 2D line, we can find the point on
-      // the 3D line with a length ratio
-      var A = Origin;
-      var B = Origin + 2 * Direction;
-      var a = plane_2d.ProjectInto(A);
-      var b = plane_2d.ProjectInto(B);
-      var len_ratio = (pI_2d - a).Length() / (b - a).Length();
-      Point3D pI = A + len_ratio * (B - A);
-
-      // and verify it belongs to both lines
-      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
-        // this is merely a 2D intersection, 3D lines do not intersect
-        return new IntersectionResult();
-      }
-
-      // all is well, yea yea
-      return new IntersectionResult(pI);
+      return new IntersectionResult(Ps);
     }
 
     public override bool Overlaps(Line3D other, int decimal_precision = Constants.THREE_DECIMALS) {
@@ -312,7 +285,7 @@ namespace GeomSharp {
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
     public override IntersectionResult Intersection(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var line_inter = Intersection(other.ToLine(), decimal_precision);
-      if (line_inter.ValueType == typeof(NullValue)) {
+      if (line_inter.ValueType != typeof(Point3D)) {
         return new IntersectionResult();
       }
 

--- a/GeomSharp/Line3D.cs
+++ b/GeomSharp/Line3D.cs
@@ -23,6 +23,14 @@ namespace GeomSharp {
             ? throw new NullLengthException("trying to initialize a line with two identical points")
             : new Line3D(p0, p1);
 
+    public static Line3D FromPoints_NoThrow(Point3D p0, Point3D p1, int decimal_precision = Constants.THREE_DECIMALS) {
+      try {
+        return FromPoints(p0, p1, decimal_precision);
+      } catch (Exception ex) {
+      }
+      return null;
+    }
+
     public static Line3D FromDirection(Point3D orig, UnitVector3D dir) => new Line3D(orig, dir);
 
     private Line3D(Point3D p0, Point3D p1) {

--- a/GeomSharp/Line3D.cs
+++ b/GeomSharp/Line3D.cs
@@ -161,6 +161,7 @@ namespace GeomSharp {
     //  plane
     public override bool Intersects(Plane other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
+
     public override IntersectionResult Intersection(Plane other, int decimal_precision = Constants.THREE_DECIMALS) {
       if (other.Contains(this, decimal_precision)) {
         return new IntersectionResult();

--- a/GeomSharp/Line3D.cs
+++ b/GeomSharp/Line3D.cs
@@ -291,20 +291,10 @@ namespace GeomSharp {
 
     //  ray
     public override bool Intersects(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
-        Intersection(other, decimal_precision).ValueType != typeof(NullValue);
-    public override IntersectionResult Intersection(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) {
-      var line_inter = Intersection(other.ToLine(), decimal_precision);
-      if (line_inter.ValueType != typeof(Point3D)) {
-        return new IntersectionResult();
-      }
+        other.Intersects(this, decimal_precision);
+    public override IntersectionResult Intersection(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
+        other.Intersection(this, decimal_precision);
 
-      var pI = (Point3D)line_inter.Value;
-      if (other.Contains(pI, decimal_precision)) {
-        return new IntersectionResult(pI);
-      }
-
-      return new IntersectionResult();
-    }
     public override bool Overlaps(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Overlap(other, decimal_precision).ValueType != typeof(NullValue);
     public override IntersectionResult Overlap(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) {

--- a/GeomSharp/LineSegment2D.cs
+++ b/GeomSharp/LineSegment2D.cs
@@ -113,9 +113,6 @@ namespace GeomSharp {
       }
 
       var pI = (Point2D)line_inter.Value;
-      if (!Contains(pI, decimal_precision)) {
-        return new IntersectionResult();
-      }
       return new IntersectionResult(pI);
     }
     public override bool Overlaps(Line2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
@@ -126,22 +123,10 @@ namespace GeomSharp {
             : new IntersectionResult();
 
     //  line segment
-    public override bool Intersects(LineSegment2D other, int decimal_precision = Constants.THREE_DECIMALS) {
-      if (Overlaps(other, decimal_precision)) {  // avoiding rewriting the same code
-        return false;
-      }
+    public override bool Intersects(LineSegment2D other,
+                                    int decimal_precision = Constants.THREE_DECIMALS) => Intersection(other).ValueType
+                                                                                         != typeof(NullValue);
 
-      // I examine all cases to avoid the overflow problem caused by the (more simple) DistanceTo(P0)*DistanceTo(P1) < 0
-      (double d_this_other_p0, double d_this_other_p1, double d_other_this_p0, double d_other_this_p1) =
-          (Math.Round(SignedDistanceTo(other.P0), decimal_precision),
-           Math.Round(SignedDistanceTo(other.P1), decimal_precision),
-           Math.Round(other.SignedDistanceTo(P0), decimal_precision),
-           Math.Round(other.SignedDistanceTo(P1),
-                      decimal_precision));  // rounding issues will kill you if unmanaged
-
-      return ((d_this_other_p0 >= 0 && d_this_other_p1 <= 0) || (d_this_other_p0 <= 0 && d_this_other_p1 >= 0)) &&
-             ((d_other_this_p0 >= 0 && d_other_this_p1 <= 0) || (d_other_this_p0 <= 0 && d_other_this_p1 >= 0));
-    }
     public override IntersectionResult Intersection(LineSegment2D other,
                                                     int decimal_precision = Constants.THREE_DECIMALS) {
       var line_intersection = ToLine().Intersection(other.ToLine(), decimal_precision);
@@ -150,9 +135,6 @@ namespace GeomSharp {
       }
 
       var pI = (Point2D)line_intersection.Value;
-      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
-        return new IntersectionResult();
-      }
       return new IntersectionResult(pI);
     }
     public override bool Overlaps(LineSegment2D other, int decimal_precision = Constants.THREE_DECIMALS) {
@@ -239,9 +221,7 @@ namespace GeomSharp {
       }
 
       var pI = (Point2D)line_inter.Value;
-      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
-        return new IntersectionResult();
-      }
+
       return new IntersectionResult(pI);
     }
     public override bool Overlaps(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) =>

--- a/GeomSharp/LineSegment2D.cs
+++ b/GeomSharp/LineSegment2D.cs
@@ -113,6 +113,9 @@ namespace GeomSharp {
       }
 
       var pI = (Point2D)line_inter.Value;
+      if (!Contains(pI, decimal_precision)) {
+        return new IntersectionResult();
+      }
       return new IntersectionResult(pI);
     }
     public override bool Overlaps(Line2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
@@ -135,6 +138,9 @@ namespace GeomSharp {
       }
 
       var pI = (Point2D)line_intersection.Value;
+      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
+        return new IntersectionResult();
+      }
       return new IntersectionResult(pI);
     }
     public override bool Overlaps(LineSegment2D other, int decimal_precision = Constants.THREE_DECIMALS) {
@@ -221,7 +227,9 @@ namespace GeomSharp {
       }
 
       var pI = (Point2D)line_inter.Value;
-
+      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
+        return new IntersectionResult();
+      }
       return new IntersectionResult(pI);
     }
     public override bool Overlaps(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) =>

--- a/GeomSharp/LineSegment2D.cs
+++ b/GeomSharp/LineSegment2D.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -110,7 +108,7 @@ namespace GeomSharp {
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
     public override IntersectionResult Intersection(Line2D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var line_inter = ToLine().Intersection(other, decimal_precision);
-      if (line_inter.ValueType == typeof(NullValue)) {
+      if (line_inter.ValueType != typeof(Point2D)) {
         return new IntersectionResult();
       }
 
@@ -146,34 +144,16 @@ namespace GeomSharp {
     }
     public override IntersectionResult Intersection(LineSegment2D other,
                                                     int decimal_precision = Constants.THREE_DECIMALS) {
-      if (IsParallel(other, decimal_precision)) {
+      var line_intersection = ToLine().Intersection(other.ToLine(), decimal_precision);
+      if (line_intersection.ValueType != typeof(Point2D)) {
         return new IntersectionResult();
       }
-      // TODO: can be put this code in a common place, and avoid duplicating it over and over ?
-      var V = other.P1 - other.P0;
-      var U = P1 - P0;
-      var W = P0 - other.P0;
 
-      double sI = -V.PerpProduct(W) / V.PerpProduct(U);  // guaranteed non-zero if non-parallel
-
-      double tI = U.PerpProduct(W) / U.PerpProduct(V);  // guaranteed non-zero if non-parallel
-
-      if (Math.Round(sI, decimal_precision) >= 0 && Math.Round(sI, decimal_precision) <= 1 &&
-          Math.Round(tI, decimal_precision) >= 0 && Math.Round(tI, decimal_precision) <= 1) {
-        // intersection: the point Ps cannot possibly be outside of the segment!
-        var Ps = P0 + sI * (P1 - P0);
-        if (!Contains(Ps, decimal_precision)) {
-          throw new Exception("Intersects() miscalculated Ps");
-        }
-        // intersection: the point Qs cannot possibly be outside the other segment!
-        var Qs = other.P0 + tI * (other.P1 - other.P0);
-        if (!other.Contains(Qs, decimal_precision)) {
-          throw new Exception("Intersects() miscalculated Qs");
-        }
-        return new IntersectionResult(Ps);
+      var pI = (Point2D)line_intersection.Value;
+      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
+        return new IntersectionResult();
       }
-
-      return new IntersectionResult();
+      return new IntersectionResult(pI);
     }
     public override bool Overlaps(LineSegment2D other, int decimal_precision = Constants.THREE_DECIMALS) {
       if (!IsParallel(other, decimal_precision)) {
@@ -254,7 +234,7 @@ namespace GeomSharp {
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
     public override IntersectionResult Intersection(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var line_inter = ToLine().Intersection(other.ToLine(), decimal_precision);
-      if (line_inter.ValueType == typeof(NullValue)) {
+      if (line_inter.ValueType != typeof(Point2D)) {
         return new IntersectionResult();
       }
 

--- a/GeomSharp/LineSegment3D.cs
+++ b/GeomSharp/LineSegment3D.cs
@@ -233,9 +233,7 @@ namespace GeomSharp {
       }
 
       var pI = (Point3D)int_res.Value;
-      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
-        return new IntersectionResult();
-      }
+
       return new IntersectionResult(pI);
     }
 
@@ -306,6 +304,7 @@ namespace GeomSharp {
     //  ray
     public override bool Intersects(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
+
     public override IntersectionResult Intersection(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var line_inter = ToLine().Intersection(other.ToLine(), decimal_precision);
       if (line_inter.ValueType != typeof(Point3D)) {
@@ -313,9 +312,6 @@ namespace GeomSharp {
       }
 
       var pI = (Point3D)line_inter.Value;
-      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
-        return new IntersectionResult();
-      }
 
       return new IntersectionResult(pI);
     }

--- a/GeomSharp/LineSegment3D.cs
+++ b/GeomSharp/LineSegment3D.cs
@@ -206,7 +206,7 @@ namespace GeomSharp {
       }
 
       var pI = (Point3D)line_inter.Value;
-      if (other.Contains(pI, decimal_precision)) {
+      if (Contains(pI, decimal_precision)) {
         return new IntersectionResult(pI);
       }
 
@@ -233,7 +233,9 @@ namespace GeomSharp {
       }
 
       var pI = (Point3D)int_res.Value;
-
+      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
+        return new IntersectionResult();
+      }
       return new IntersectionResult(pI);
     }
 
@@ -312,7 +314,9 @@ namespace GeomSharp {
       }
 
       var pI = (Point3D)line_inter.Value;
-
+      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
+        return new IntersectionResult();
+      }
       return new IntersectionResult(pI);
     }
     public override bool Overlaps(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) =>

--- a/GeomSharp/LineSegment3D.cs
+++ b/GeomSharp/LineSegment3D.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -203,7 +201,7 @@ namespace GeomSharp {
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
     public override IntersectionResult Intersection(Line3D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var line_inter = other.Intersection(ToLine(), decimal_precision);
-      if (line_inter.ValueType == typeof(NullValue)) {
+      if (line_inter.ValueType != typeof(Point3D)) {
         return new IntersectionResult();
       }
 
@@ -230,15 +228,15 @@ namespace GeomSharp {
                                                     int decimal_precision = Constants.THREE_DECIMALS) {
       var int_res = ToLine().Intersection(other.ToLine(), decimal_precision);
 
-      if (int_res.ValueType == typeof(NullValue)) {
+      if (int_res.ValueType != typeof(Point3D)) {
         return new IntersectionResult();
       }
 
       var pI = (Point3D)int_res.Value;
-      if (Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision)) {
-        return new IntersectionResult(pI);
+      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
+        return new IntersectionResult();
       }
-      return new IntersectionResult();
+      return new IntersectionResult(pI);
     }
 
     public override bool Overlaps(LineSegment3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
@@ -310,16 +308,16 @@ namespace GeomSharp {
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
     public override IntersectionResult Intersection(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var line_inter = ToLine().Intersection(other.ToLine(), decimal_precision);
-      if (line_inter.ValueType == typeof(NullValue)) {
+      if (line_inter.ValueType != typeof(Point3D)) {
         return new IntersectionResult();
       }
 
       var pI = (Point3D)line_inter.Value;
-      if (Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision)) {
-        return new IntersectionResult(pI);
+      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
+        return new IntersectionResult();
       }
 
-      return new IntersectionResult();
+      return new IntersectionResult(pI);
     }
     public override bool Overlaps(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Overlap(other, decimal_precision).ValueType != typeof(NullValue);

--- a/GeomSharp/Plane.cs
+++ b/GeomSharp/Plane.cs
@@ -197,9 +197,6 @@ namespace GeomSharp {
       double sI = -n.DotProduct(W) / denom;
       var q = p + sI * U;
 
-      // if (!Contains(q, decimal_precision)) {
-      //   throw new Exception("ProjectOnto failed (no plane contains)");
-      // }
       return q;
     }
 
@@ -227,10 +224,6 @@ namespace GeomSharp {
       }
 
       Point3D q = p + sI * U;
-
-      // if (!Contains(q, decimal_precision)) {
-      //   throw new Exception("VerticalProjectOnto failed");
-      // }
 
       return q;
     }
@@ -387,10 +380,6 @@ namespace GeomSharp {
       (double d1, double d2) = (-Normal.DotProduct(Origin), -other.Normal.DotProduct(other.Origin));
 
       var pI = Point3D.Zero + (d2 * Normal - d1 * other.Normal).CrossProduct(U) / U.DotProduct(U);
-
-      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
-        throw new Exception("plane.Intersection(plane) failed computation: pI does not belong to planes");
-      }
 
       return new IntersectionResult(Line3D.FromDirection(pI, U.Normalize()));
     }

--- a/GeomSharp/Plane.cs
+++ b/GeomSharp/Plane.cs
@@ -197,6 +197,10 @@ namespace GeomSharp {
       double sI = -n.DotProduct(W) / denom;
       var q = p + sI * U;
 
+      if (!Contains(q)) {
+        throw new Exception("ProjectOnto failed");
+      }
+
       return q;
     }
 
@@ -224,6 +228,9 @@ namespace GeomSharp {
       }
 
       Point3D q = p + sI * U;
+      if (!Contains(q)) {
+        throw new Exception("ProjectOnto failed");
+      }
 
       return q;
     }
@@ -380,6 +387,10 @@ namespace GeomSharp {
       (double d1, double d2) = (-Normal.DotProduct(Origin), -other.Normal.DotProduct(other.Origin));
 
       var pI = Point3D.Zero + (d2 * Normal - d1 * other.Normal).CrossProduct(U) / U.DotProduct(U);
+
+      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
+        throw new Exception("plane.Intersection(plane) failed computation: pI does not belong to planes");
+      }
 
       return new IntersectionResult(Line3D.FromDirection(pI, U.Normalize()));
     }

--- a/GeomSharp/Plane.cs
+++ b/GeomSharp/Plane.cs
@@ -176,9 +176,9 @@ namespace GeomSharp {
     /// </summary>
     /// <param name="p"></param>
     /// <returns></returns>
-    public Point3D ProjectOnto(Point3D p) {
+    public Point3D ProjectOnto(Point3D p, int decimal_precision = Constants.THREE_DECIMALS) {
       // funny edge case
-      if (Contains(p)) {
+      if (Contains(p, decimal_precision)) {
         return p;
       }
 
@@ -189,12 +189,17 @@ namespace GeomSharp {
       var U = -SignedDistance(p) * Normal;
       var W = p - Origin;
       var n = Normal;
-      double sI = -n.DotProduct(W) / n.DotProduct(U);
+      double denom = n.DotProduct(U);
+      if (Math.Round(denom, decimal_precision) == 0) {
+        throw new Exception("ProjectOnto failed (div-zero)");
+      }
+
+      double sI = -n.DotProduct(W) / denom;
       var q = p + sI * U;
 
-      if (!Contains(q)) {
-        throw new Exception("ProjectOnto failed");
-      }
+      // if (!Contains(q, decimal_precision)) {
+      //   throw new Exception("ProjectOnto failed (no plane contains)");
+      // }
       return q;
     }
 
@@ -204,9 +209,9 @@ namespace GeomSharp {
     /// <param name="p"></param>
     /// <returns></returns>
     /// <exception cref="Exception"></exception>
-    public Point3D ProjectOnto(Point3D p, UnitVector3D proj_axis) {
+    public Point3D ProjectOnto(Point3D p, UnitVector3D proj_axis, int decimal_precision = Constants.THREE_DECIMALS) {
       // funny edge case
-      if (Contains(p)) {
+      if (Contains(p, decimal_precision)) {
         return p;
       }
 
@@ -214,14 +219,18 @@ namespace GeomSharp {
       var U = proj_axis;
       var W = p - Origin;
       var n = Normal;
+      double denom = n.DotProduct(U);
 
-      double sI = -n.DotProduct(W) / n.DotProduct(U);
+      double sI = -n.DotProduct(W) / denom;
+      if (Math.Round(denom, decimal_precision) == 0) {
+        throw new Exception("ProjectOnto failed (div-zero)");
+      }
 
       Point3D q = p + sI * U;
 
-      if (!Contains(q)) {
-        throw new Exception("VerticalProjectOnto failed");
-      }
+      // if (!Contains(q, decimal_precision)) {
+      //   throw new Exception("VerticalProjectOnto failed");
+      // }
 
       return q;
     }
@@ -232,7 +241,8 @@ namespace GeomSharp {
     /// <param name="p"></param>
     /// <returns></returns>
     /// <exception cref="Exception"></exception>
-    public Point3D VerticalProjectOnto(Point3D p) => ProjectOnto(p, Vector3D.AxisZ);
+    public Point3D VerticalProjectOnto(Point3D p, int decimal_precision = Constants.THREE_DECIMALS) =>
+        ProjectOnto(p, Vector3D.AxisZ, decimal_precision);
 
     /// <summary>
     /// Project given 3D XYZ point into plane,
@@ -246,8 +256,8 @@ namespace GeomSharp {
     /// ProjectInto projects the Point3D p onto the same 3D plane. Then projects the point on the AxisU and AxisV of
     /// the plane, and returns the 2D coordinates of the point along the basis AxisU,AxisV.
     /// </summary>
-    public Point2D ProjectInto(Point3D p) {
-      var q = ProjectOnto(p);
+    public Point2D ProjectInto(Point3D p, int decimal_precision = Constants.THREE_DECIMALS) {
+      var q = ProjectOnto(p, decimal_precision);
       var B = q - Origin;
       double B_len = B.Length();
       double B_cos = B.DotProduct(AxisU);
@@ -281,8 +291,8 @@ namespace GeomSharp {
     /// ProjectInto projects the Point3D p onto the same 3D plane. Then projects the point on the AxisU and AxisV of
     /// the plane, and returns the 2D coordinates of the point along the basis AxisU,AxisV.
     /// </summary>
-    public Point2D VerticalProjectInto(Point3D p) {
-      var q = VerticalProjectOnto(p);
+    public Point2D VerticalProjectInto(Point3D p, int decimal_precision = Constants.THREE_DECIMALS) {
+      var q = VerticalProjectOnto(p, decimal_precision);
       var B = q - Origin;
       double B_len = B.Length();
       double B_cos = B.DotProduct(AxisU);

--- a/GeomSharp/Ray2D.cs
+++ b/GeomSharp/Ray2D.cs
@@ -114,9 +114,20 @@ namespace GeomSharp {
 
     //  line
     public override bool Intersects(Line2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
-        other.Intersects(this, decimal_precision);
-    public override IntersectionResult Intersection(Line2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
-        other.Intersection(this, decimal_precision);
+        Intersection(other, decimal_precision).ValueType != typeof(NullValue);
+    public override IntersectionResult Intersection(Line2D other, int decimal_precision = Constants.THREE_DECIMALS) {
+      var line_inter = ToLine().Intersection(other, decimal_precision);
+      if (line_inter.ValueType != typeof(Point2D)) {
+        return new IntersectionResult();
+      }
+
+      var pI = (Point2D)line_inter.Value;
+      if (!Contains(pI, decimal_precision)) {
+        return new IntersectionResult();
+      }
+      return new IntersectionResult(pI);
+    }
+
     public override bool Overlaps(Line2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         other.Overlaps(this, decimal_precision);
     public override IntersectionResult Overlap(Line2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
@@ -177,9 +188,11 @@ namespace GeomSharp {
         return new IntersectionResult();
       }
 
-      var Ps = (Point2D)line_int.Value;
-
-      return new IntersectionResult(Ps);
+      var pI = (Point2D)line_int.Value;
+      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
+        return new IntersectionResult();
+      }
+      return new IntersectionResult(pI);
     }
     public override bool Overlaps(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Overlap(other, decimal_precision).ValueType != typeof(NullValue);

--- a/GeomSharp/Ray2D.cs
+++ b/GeomSharp/Ray2D.cs
@@ -170,6 +170,7 @@ namespace GeomSharp {
     //  ray
     public override bool Intersects(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
+
     public override IntersectionResult Intersection(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var line_int = ToLine().Intersection(other.ToLine(), decimal_precision);
       if (line_int.ValueType != typeof(Point2D)) {
@@ -177,9 +178,6 @@ namespace GeomSharp {
       }
 
       var Ps = (Point2D)line_int.Value;
-      if (!(Contains(Ps, decimal_precision) && other.Contains(Ps, decimal_precision))) {
-        return new IntersectionResult();
-      }
 
       return new IntersectionResult(Ps);
     }

--- a/GeomSharp/Ray2D.cs
+++ b/GeomSharp/Ray2D.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -174,7 +172,7 @@ namespace GeomSharp {
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
     public override IntersectionResult Intersection(Ray2D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var line_int = ToLine().Intersection(other.ToLine(), decimal_precision);
-      if (line_int.ValueType == typeof(NullValue)) {
+      if (line_int.ValueType != typeof(Point2D)) {
         return new IntersectionResult();
       }
 

--- a/GeomSharp/Ray3D.cs
+++ b/GeomSharp/Ray3D.cs
@@ -219,7 +219,7 @@ namespace GeomSharp {
       }
 
       var Ps = (Point3D)line_int.Value;
-      if (!(Contains(Ps) && other.Contains(Ps))) {
+      if (!(Contains(Ps, decimal_precision) && other.Contains(Ps, decimal_precision))) {
         return new IntersectionResult();
       }
 

--- a/GeomSharp/Ray3D.cs
+++ b/GeomSharp/Ray3D.cs
@@ -212,6 +212,7 @@ namespace GeomSharp {
     //  ray
     public override bool Intersects(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
+
     public override IntersectionResult Intersection(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var line_int = ToLine().Intersection(other.ToLine(), decimal_precision);
       if (line_int.ValueType != typeof(Point3D)) {
@@ -219,9 +220,6 @@ namespace GeomSharp {
       }
 
       var Ps = (Point3D)line_int.Value;
-      if (!(Contains(Ps, decimal_precision) && other.Contains(Ps, decimal_precision))) {
-        return new IntersectionResult();
-      }
 
       return new IntersectionResult(Ps);
     }

--- a/GeomSharp/Ray3D.cs
+++ b/GeomSharp/Ray3D.cs
@@ -113,9 +113,9 @@ namespace GeomSharp {
 
       Point3D q = Origin + sI * U;
 
-      // if (!other.Contains(q, decimal_precision)) {
-      //   throw new Exception("plane.Intersection(Line3D) failed");
-      // }
+      if (!other.Contains(q, decimal_precision)) {
+        throw new Exception("plane.Intersection(Line3D) failed");
+      }
 
       return new IntersectionResult(q);
     }
@@ -156,9 +156,23 @@ namespace GeomSharp {
 
     //  line
     public override bool Intersects(Line3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
-        other.Intersects(this, decimal_precision);
-    public override IntersectionResult Intersection(Line3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
-        other.Intersection(this, decimal_precision);
+        Intersection(other, decimal_precision).ValueType != typeof(NullValue);
+    public override IntersectionResult Intersection(Line3D other, int decimal_precision = Constants.THREE_DECIMALS) {
+      {
+        var line_inter = ToLine().Intersection(other, decimal_precision);
+        if (line_inter.ValueType != typeof(Point3D)) {
+          return new IntersectionResult();
+        }
+
+        var pI = (Point3D)line_inter.Value;
+        if (!Contains(pI, decimal_precision)) {
+          return new IntersectionResult(pI);
+        }
+
+        return new IntersectionResult();
+      }
+    }
+
     public override bool Overlaps(Line3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         other.Overlaps(this, decimal_precision);
     public override IntersectionResult Overlap(Line3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
@@ -219,9 +233,11 @@ namespace GeomSharp {
         return new IntersectionResult();
       }
 
-      var Ps = (Point3D)line_int.Value;
-
-      return new IntersectionResult(Ps);
+      var pI = (Point3D)line_int.Value;
+      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
+        return new IntersectionResult();
+      }
+      return new IntersectionResult(pI);
     }
     public override bool Overlaps(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Overlap(other, decimal_precision).ValueType != typeof(NullValue);

--- a/GeomSharp/Ray3D.cs
+++ b/GeomSharp/Ray3D.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
-using GeomSharp;
 
 namespace GeomSharp {
   /// <summary>
@@ -104,17 +101,21 @@ namespace GeomSharp {
       var W = Origin - other.Origin;
       var n = other.Normal;
 
-      double sI = -n.DotProduct(W) / n.DotProduct(U);
+      double denom = n.DotProduct(U);
+      if (Math.Round(denom, decimal_precision) == 0) {
+        return new IntersectionResult();
+      }
 
+      double sI = -n.DotProduct(W) / denom;
       if (Math.Round(sI, decimal_precision) < 0) {
         return new IntersectionResult();
       }
 
       Point3D q = Origin + sI * U;
 
-      if (!other.Contains(q, decimal_precision)) {
-        throw new Exception("plane.Intersection(Line3D) failed");
-      }
+      // if (!other.Contains(q, decimal_precision)) {
+      //   throw new Exception("plane.Intersection(Line3D) failed");
+      // }
 
       return new IntersectionResult(q);
     }
@@ -213,7 +214,7 @@ namespace GeomSharp {
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
     public override IntersectionResult Intersection(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var line_int = ToLine().Intersection(other.ToLine(), decimal_precision);
-      if (line_int.ValueType == typeof(NullValue)) {
+      if (line_int.ValueType != typeof(Point3D)) {
         return new IntersectionResult();
       }
 

--- a/GeomSharp/Triangle2D.cs
+++ b/GeomSharp/Triangle2D.cs
@@ -218,13 +218,13 @@ namespace GeomSharp {
 
       // edge 1 intersection
       edge_inter = LineSegment2D.FromPoints(P0, P1).Intersection(other, decimal_precision);
-      if (edge_inter.ValueType != typeof(NullValue)) {
+      if (edge_inter.ValueType == typeof(Point2D)) {
         pi1 = (Point2D)edge_inter.Value;
       }
 
       // edge 2 intersection
       edge_inter = LineSegment2D.FromPoints(P1, P2).Intersection(other, decimal_precision);
-      if (edge_inter.ValueType != typeof(NullValue)) {
+      if (edge_inter.ValueType == typeof(Point2D)) {
         var p = (Point2D)edge_inter.Value;
         if (pi1 is null) {
           pi1 = p;
@@ -238,7 +238,7 @@ namespace GeomSharp {
       // edge 3 intersection
       if (pi2 is null) {
         edge_inter = LineSegment2D.FromPoints(P2, P0).Intersection(other, decimal_precision);
-        if (edge_inter.ValueType != typeof(NullValue)) {
+        if (edge_inter.ValueType == typeof(Point2D)) {
           var p = (Point2D)edge_inter.Value;
           if (pi1 is null) {
             pi1 = p;

--- a/GeomSharp/Triangle2D.cs
+++ b/GeomSharp/Triangle2D.cs
@@ -728,8 +728,8 @@ namespace GeomSharp {
     }
 
     public bool IsOnPerimeter(Point2D point, int decimal_precision = Constants.THREE_DECIMALS) =>
-        LineSegment2D.FromPoints(P0, P1, decimal_precision).Contains(point) ||
-        LineSegment2D.FromPoints(P1, P2, decimal_precision).Contains(point) ||
-        LineSegment2D.FromPoints(P2, P0, decimal_precision).Contains(point);
+        LineSegment2D.FromPoints(P0, P1, decimal_precision).Contains(point, decimal_precision) ||
+        LineSegment2D.FromPoints(P1, P2, decimal_precision).Contains(point, decimal_precision) ||
+        LineSegment2D.FromPoints(P2, P0, decimal_precision).Contains(point, decimal_precision);
   }
 }

--- a/GeomSharp/Triangle3D.cs
+++ b/GeomSharp/Triangle3D.cs
@@ -265,6 +265,7 @@ namespace GeomSharp {
     //  line segment
     public override bool Intersects(LineSegment3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
+
     public override IntersectionResult Intersection(LineSegment3D other,
                                                     int decimal_precision = Constants.THREE_DECIMALS) {
       var res = RefPlane().Intersection(other, decimal_precision);
@@ -274,13 +275,12 @@ namespace GeomSharp {
 
       var pI = (Point3D)res.Value;
 
-      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
-        return new IntersectionResult();
-      }
       return new IntersectionResult(pI);
     }
+
     public override bool Overlaps(LineSegment3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Overlap(other, decimal_precision).ValueType != typeof(NullValue);
+
     public override IntersectionResult Overlap(LineSegment3D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var ref_plane = RefPlane();
       if (!ref_plane.Contains(other, decimal_precision)) {
@@ -354,6 +354,7 @@ namespace GeomSharp {
     //  ray
     public override bool Intersects(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
+
     public override IntersectionResult Intersection(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var res = RefPlane().Intersection(other, decimal_precision);
       if (res.ValueType != typeof(Point3D)) {
@@ -362,9 +363,6 @@ namespace GeomSharp {
 
       var pI = (Point3D)res.Value;
 
-      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
-        return new IntersectionResult();
-      }
       return new IntersectionResult(pI);
     }
 

--- a/GeomSharp/Triangle3D.cs
+++ b/GeomSharp/Triangle3D.cs
@@ -1,5 +1,4 @@
-﻿
-using GeomSharp.Collections;
+﻿using GeomSharp.Collections;
 
 using System;
 using System.Linq;
@@ -165,7 +164,7 @@ namespace GeomSharp {
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
     public override IntersectionResult Intersection(Plane other, int decimal_precision = Constants.THREE_DECIMALS) {
       var plane_inter = other.Intersection(RefPlane());
-      if (plane_inter.ValueType == typeof(NullValue)) {
+      if (plane_inter.ValueType != typeof(Line3D)) {
         return new IntersectionResult();
       }
 
@@ -210,7 +209,7 @@ namespace GeomSharp {
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
     public override IntersectionResult Intersection(Line3D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var res = RefPlane().Intersection(other, decimal_precision);
-      if (res.ValueType == typeof(NullValue)) {
+      if (res.ValueType != typeof(Point3D)) {
         return new IntersectionResult();
       }
 
@@ -269,17 +268,16 @@ namespace GeomSharp {
     public override IntersectionResult Intersection(LineSegment3D other,
                                                     int decimal_precision = Constants.THREE_DECIMALS) {
       var res = RefPlane().Intersection(other, decimal_precision);
-      if (res.ValueType == typeof(NullValue)) {
+      if (res.ValueType != typeof(Point3D)) {
         return new IntersectionResult();
       }
 
       var pI = (Point3D)res.Value;
 
-      if (Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision)) {
-        return new IntersectionResult(pI);
+      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
+        return new IntersectionResult();
       }
-
-      return new IntersectionResult();
+      return new IntersectionResult(pI);
     }
     public override bool Overlaps(LineSegment3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
         Overlap(other, decimal_precision).ValueType != typeof(NullValue);
@@ -358,17 +356,16 @@ namespace GeomSharp {
         Intersection(other, decimal_precision).ValueType != typeof(NullValue);
     public override IntersectionResult Intersection(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) {
       var res = RefPlane().Intersection(other, decimal_precision);
-      if (res.ValueType == typeof(NullValue)) {
+      if (res.ValueType != typeof(Point3D)) {
         return new IntersectionResult();
       }
 
       var pI = (Point3D)res.Value;
 
-      if (Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision)) {
-        return new IntersectionResult(pI);
+      if (!(Contains(pI, decimal_precision) && other.Contains(pI, decimal_precision))) {
+        return new IntersectionResult();
       }
-
-      return new IntersectionResult();
+      return new IntersectionResult(pI);
     }
 
     public override bool Overlaps(Ray3D other, int decimal_precision = Constants.THREE_DECIMALS) =>
@@ -588,7 +585,7 @@ namespace GeomSharp {
 
           // a line on the same plane passing through a triangle was defined as an overlap
           var ovlp_this = inter_line.Overlap(this);
-          if (ovlp_this.ValueType == typeof(NullValue)) {
+          if (ovlp_this.ValueType != typeof(LineSegment3D)) {
             return new IntersectionResult();
           }
 

--- a/GeomSharp/Triangle3D.cs
+++ b/GeomSharp/Triangle3D.cs
@@ -615,8 +615,8 @@ namespace GeomSharp {
     }
 
     public bool IsOnPerimeter(Point3D point, int decimal_precision = Constants.THREE_DECIMALS) =>
-        LineSegment3D.FromPoints(P0, P1, decimal_precision).Contains(point) ||
-        LineSegment3D.FromPoints(P1, P2, decimal_precision).Contains(point) ||
-        LineSegment3D.FromPoints(P2, P0, decimal_precision).Contains(point);
+        LineSegment3D.FromPoints(P0, P1, decimal_precision).Contains(point, decimal_precision) ||
+        LineSegment3D.FromPoints(P1, P2, decimal_precision).Contains(point, decimal_precision) ||
+        LineSegment3D.FromPoints(P2, P0, decimal_precision).Contains(point, decimal_precision);
   }
 }

--- a/GeomSharp/Vector2D.cs
+++ b/GeomSharp/Vector2D.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;

--- a/GeomSharp/Vector3D.cs
+++ b/GeomSharp/Vector3D.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Linq;
 
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
 
 using GeomSharp.Algebra;
-using Microsoft.SqlServer.Server;
 
 namespace GeomSharp {
   /// <summary>
@@ -121,9 +119,29 @@ namespace GeomSharp {
 
     public static Vector3D operator /(Vector3D b, double k) => FromVector(b.ToVector() / k);
 
+    public Vector3D Perp() {
+      int default_precision = Constants.THREE_DECIMALS;
+      bool is_z_biggest = Math.Round(Z - Y, default_precision) >= 0 && Math.Round(Z - X, default_precision) >= 0;
+      bool is_x_biggest = Math.Round(X - Y, default_precision) >= 0 && Math.Round(X - Z, default_precision) >= 0;
+      // bool is_y_biggest = Math.Round(Y - Z, default_precision) >= 0 && Math.Round(Y - X, default_precision) >= 0;
+
+      if (is_z_biggest) {
+        return new Vector3D(-Y, X, 0);
+      }
+
+      if (is_x_biggest) {
+        return new Vector3D(0, -Z, Y);
+      }
+
+      // if (is_y_biggest) { }
+      return new Vector3D(Z, 0, -X);
+    }
+
     public double DotProduct(Vector3D other) => ToVector().DotProduct(other.ToVector());
 
     public double DotProduct(Point3D point) => ToVector().DotProduct(point.ToVector());
+
+    public double PerpProduct(Vector3D other) => Perp().DotProduct(other);
 
     /// <summary>
     /// The cross product (aka 3D outer product)

--- a/GeomSharpTests/Line2DTests.cs
+++ b/GeomSharpTests/Line2DTests.cs
@@ -63,64 +63,97 @@ namespace GeomSharpTests {
       // temp data
       LineSegment2D other;
       Vector2D u_perp = u.Perp();
+      IntersectionResult int_res = null;
+      Point2D int_pt = null;
 
       // case 1: intersect forrreal
       //      in the middle, crossing
       other = LineSegment2D.FromPoints(mid - 2 * u_perp, mid + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      on the first extremity, crossing
       other = LineSegment2D.FromPoints(p0 - 2 * u_perp, p0 + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other), "intersect forrreal (p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
+                    "intersect forrreal (p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      on the second extremity, crossing
       other = LineSegment2D.FromPoints(p1 - 2 * u_perp, p1 + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other), "intersect forrreal (p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
+                    "intersect forrreal (p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the middle, going down
       other = LineSegment2D.FromPoints(mid - 2 * u_perp, mid);
-      Assert.IsTrue(seg.Intersects(other),
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (to mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (to mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the middle, going up
       other = LineSegment2D.FromPoints(mid, mid + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other),
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the the first extremity, going down
       other = LineSegment2D.FromPoints(p0 - 2 * u_perp, p0);
-      Assert.IsTrue(seg.Intersects(other),
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (to p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (to p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the the first extremity, going up
       other = LineSegment2D.FromPoints(p0 + 2 * u_perp, p0);
-      Assert.IsTrue(seg.Intersects(other),
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the the second extremity, going up
       other = LineSegment2D.FromPoints(p1, p1 + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other),
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the the second extremity, going down
       other = LineSegment2D.FromPoints(p1, p1 - 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other),
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (to p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (to p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       // case 2: no intersection (parallel, shift random vector)
       //      upwards
       Vector2D shift = RandomGenerator.MakeVector2D();
       other = LineSegment2D.FromPoints(p0 + 2 * shift, p1 + 2 * shift);
-      Assert.IsFalse(
-          seg.Intersects(other),
+      Assert.IsTrue(
+          int_res.ValueType == typeof(NullValue),
           "no intersection (parallel, shift upwards random vector)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      downwards
       other = LineSegment2D.FromPoints(p0 - 2 * shift, p1 - 2 * shift);
-      Assert.IsFalse(seg.Intersects(other),
-                     "no intersection (parallel, shift downwards random vector)" + "\ns1=" + seg.ToWkt() +
-                         ", s2=" + other.ToWkt());
+      other = LineSegment2D.FromPoints(p0 + 2 * shift, p1 + 2 * shift);
+      Assert.IsTrue(int_res.ValueType == typeof(NullValue),
+                    "no intersection (parallel, shift downwards random vector)" + "\ns1=" + seg.ToWkt() +
+                        ", s2=" + other.ToWkt());
     }
 
     [RepeatedTestMethod(100)]

--- a/GeomSharpTests/Line3DTests.cs
+++ b/GeomSharpTests/Line3DTests.cs
@@ -52,6 +52,8 @@ namespace GeomSharpTests {
 
     [RepeatedTestMethod(100)]
     public void Intersection() {
+      int default_precision = Constants.THREE_DECIMALS;
+
       // input
       (var line, var p0, var p1) = RandomGenerator.MakeLine3D();
 
@@ -63,67 +65,89 @@ namespace GeomSharpTests {
 
       // temp data
       Line3D other;
-      Vector3D u_perp = u.CrossProduct((u.IsParallel(Vector3D.AxisZ) ? Vector3D.AxisY : Vector3D.AxisZ));
+      Vector3D u_perp = u.Perp();
 
       // case 1: intersect forrreal
       //      in the middle, crossing
-      other = Line3D.FromPoints(mid - 2 * u_perp, mid + 2 * u_perp);
-      Assert.IsTrue(line.Intersects(other),
-                    "intersect forrreal (mid)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      other = Line3D.FromPoints_NoThrow(mid - 2 * u_perp, mid + 2 * u_perp, default_precision);
+      if (other != null) {
+        Assert.IsTrue(line.Intersects(other, default_precision),
+                      "intersect forrreal (mid)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      }
 
       //      on the first extremity, crossing
-      other = Line3D.FromPoints(p0 - 2 * u_perp, p0 + 2 * u_perp);
-      Assert.IsTrue(line.Intersects(other),
-                    "intersect forrreal (p0)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      other = Line3D.FromPoints_NoThrow(p0 - 2 * u_perp, p0 + 2 * u_perp, default_precision);
+      if (other != null) {
+        Assert.IsTrue(line.Intersects(other, default_precision),
+                      "intersect forrreal (p0)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      }
 
       //      on the second extremity, crossing
-      other = Line3D.FromPoints(p1 - 2 * u_perp, p1 + 2 * u_perp);
-      Assert.IsTrue(line.Intersects(other),
-                    "intersect forrreal (p1)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      other = Line3D.FromPoints_NoThrow(p1 - 2 * u_perp, p1 + 2 * u_perp, default_precision);
+      if (other != null) {
+        Assert.IsTrue(line.Intersects(other),
+                      "intersect forrreal (p1)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      }
 
       //      just one point in the middle, going down
-      other = Line3D.FromPoints(mid - 2 * u_perp, mid);
-      Assert.IsTrue(line.Intersects(other),
-                    "intersect forrreal (to mid)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      other = Line3D.FromPoints_NoThrow(mid - 2 * u_perp, mid, default_precision);
+      if (other != null) {
+        Assert.IsTrue(line.Intersects(other, default_precision),
+                      "intersect forrreal (to mid)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      }
 
       //      just one point in the middle, going up
-      other = Line3D.FromPoints(mid, mid + 2 * u_perp);
-      Assert.IsTrue(line.Intersects(other),
-                    "intersect forrreal (from mid)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      other = Line3D.FromPoints_NoThrow(mid, mid + 2 * u_perp, default_precision);
+      if (other != null) {
+        Assert.IsTrue(line.Intersects(other, default_precision),
+                      "intersect forrreal (from mid)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      }
 
       //      just one point in the the first extremity, going down
-      other = Line3D.FromPoints(p0 - 2 * u_perp, p0);
-      Assert.IsTrue(line.Intersects(other),
-                    "intersect forrreal (to p0)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      other = Line3D.FromPoints_NoThrow(p0 - 2 * u_perp, p0, default_precision);
+      if (other != null) {
+        Assert.IsTrue(line.Intersects(other, default_precision),
+                      "intersect forrreal (to p0)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      }
 
       //      just one point in the the first extremity, going up
-      other = Line3D.FromPoints(p0 + 2 * u_perp, p0);
-      Assert.IsTrue(line.Intersects(other),
-                    "intersect forrreal (from p0)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      other = Line3D.FromPoints_NoThrow(p0 + 2 * u_perp, p0, default_precision);
+      if (other != null) {
+        Assert.IsTrue(line.Intersects(other, default_precision),
+                      "intersect forrreal (from p0)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      }
 
       //      just one point in the the second extremity, going up
-      other = Line3D.FromPoints(p1, p1 + 2 * u_perp);
-      Assert.IsTrue(line.Intersects(other),
-                    "intersect forrreal (from p1)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      other = Line3D.FromPoints_NoThrow(p1, p1 + 2 * u_perp, default_precision);
+      if (other != null) {
+        Assert.IsTrue(line.Intersects(other, default_precision),
+                      "intersect forrreal (from p1)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      }
 
       //      just one point in the the second extremity, going down
-      other = Line3D.FromPoints(p1, p1 - 2 * u_perp);
-      Assert.IsTrue(line.Intersects(other),
-                    "intersect forrreal (to p1)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      other = Line3D.FromPoints_NoThrow(p1, p1 - 2 * u_perp, default_precision);
+      if (other != null) {
+        Assert.IsTrue(line.Intersects(other, default_precision),
+                      "intersect forrreal (to p1)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+      }
 
       // case 2: no intersection (parallel, shift random vector)
       //      upwards
       Vector3D shift = RandomGenerator.MakeVector3D();
-      other = Line3D.FromPoints(p0 + 2 * shift, p1 + 2 * shift);
-      Assert.IsFalse(line.Intersects(other),
-                     "no intersection (parallel, shift upwards random vector)" + "\n\tl1=" + line.ToWkt() +
-                         "\n\tl2=" + other.ToWkt());
+      other = Line3D.FromPoints_NoThrow(p0 + 2 * shift, p1 + 2 * shift, default_precision);
+      if (other != null) {
+        Assert.IsFalse(line.Intersects(other, default_precision),
+                       "no intersection (parallel, shift upwards random vector)" + "\n\tl1=" + line.ToWkt() +
+                           "\n\tl2=" + other.ToWkt());
+      }
 
       //      downwards
-      other = Line3D.FromPoints(p0 - 2 * shift, p1 - 2 * shift);
-      Assert.IsFalse(line.Intersects(other),
-                     "no intersection (parallel, shift downwards random vector)" + "\n\tl1=" + line.ToWkt() +
-                         "\n\tl2=" + other.ToWkt());
+      other = Line3D.FromPoints_NoThrow(p0 - 2 * shift, p1 - 2 * shift, default_precision);
+      if (other != null) {
+        Assert.IsFalse(line.Intersects(other, default_precision),
+                       "no intersection (parallel, shift downwards random vector)" + "\n\tl1=" + line.ToWkt() +
+                           "\n\tl2=" + other.ToWkt());
+      }
     }
 
     [RepeatedTestMethod(100)]

--- a/GeomSharpTests/Line3DTests.cs
+++ b/GeomSharpTests/Line3DTests.cs
@@ -52,8 +52,6 @@ namespace GeomSharpTests {
 
     [RepeatedTestMethod(100)]
     public void Intersection() {
-      int default_precision = Constants.THREE_DECIMALS;
-
       // input
       (var line, var p0, var p1) = RandomGenerator.MakeLine3D();
 
@@ -66,87 +64,127 @@ namespace GeomSharpTests {
       // temp data
       Line3D other;
       Vector3D u_perp = u.Perp();
+      IntersectionResult int_res = null;
+      Point3D int_pt = null;
 
       // case 1: intersect forrreal
       //      in the middle, crossing
-      other = Line3D.FromPoints_NoThrow(mid - 2 * u_perp, mid + 2 * u_perp, default_precision);
+      other = Line3D.FromPoints_NoThrow(mid - 2 * u_perp, mid + 2 * u_perp);
       if (other != null) {
-        Assert.IsTrue(line.Intersects(other, default_precision),
-                      "intersect forrreal (mid)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+        int_res = line.Intersection(other);
+        Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                      "intersect forrreal (mid)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
+        int_pt = (Point3D)int_res.Value;
+        Assert.IsTrue(line.Contains(int_pt) && other.Contains(int_pt),
+                      "intersect forrreal (mid)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
       }
 
       //      on the first extremity, crossing
-      other = Line3D.FromPoints_NoThrow(p0 - 2 * u_perp, p0 + 2 * u_perp, default_precision);
+      other = Line3D.FromPoints_NoThrow(p0 - 2 * u_perp, p0 + 2 * u_perp);
       if (other != null) {
-        Assert.IsTrue(line.Intersects(other, default_precision),
-                      "intersect forrreal (p0)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+        int_res = line.Intersection(other);
+        Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                      "intersect forrreal (p0)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
+        int_pt = (Point3D)int_res.Value;
+        Assert.IsTrue(line.Contains(int_pt) && other.Contains(int_pt),
+                      "intersect forrreal (p0)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
       }
 
       //      on the second extremity, crossing
-      other = Line3D.FromPoints_NoThrow(p1 - 2 * u_perp, p1 + 2 * u_perp, default_precision);
+      other = Line3D.FromPoints_NoThrow(p1 - 2 * u_perp, p1 + 2 * u_perp);
       if (other != null) {
-        Assert.IsTrue(line.Intersects(other),
-                      "intersect forrreal (p1)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+        int_res = line.Intersection(other);
+        Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                      "intersect forrreal (p1)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
+        int_pt = (Point3D)int_res.Value;
+        Assert.IsTrue(line.Contains(int_pt) && other.Contains(int_pt),
+                      "intersect forrreal (p1)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
       }
 
       //      just one point in the middle, going down
-      other = Line3D.FromPoints_NoThrow(mid - 2 * u_perp, mid, default_precision);
+      other = Line3D.FromPoints_NoThrow(mid - 2 * u_perp, mid);
       if (other != null) {
-        Assert.IsTrue(line.Intersects(other, default_precision),
-                      "intersect forrreal (to mid)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+        int_res = line.Intersection(other);
+        Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                      "intersect forrreal (to mid)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
+        int_pt = (Point3D)int_res.Value;
+        Assert.IsTrue(line.Contains(int_pt) && other.Contains(int_pt),
+                      "intersect forrreal (to mid)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
       }
 
       //      just one point in the middle, going up
-      other = Line3D.FromPoints_NoThrow(mid, mid + 2 * u_perp, default_precision);
+      other = Line3D.FromPoints_NoThrow(mid, mid + 2 * u_perp);
       if (other != null) {
-        Assert.IsTrue(line.Intersects(other, default_precision),
-                      "intersect forrreal (from mid)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+        int_res = line.Intersection(other);
+        Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                      "intersect forrreal (from mid)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
+        int_pt = (Point3D)int_res.Value;
+        Assert.IsTrue(line.Contains(int_pt) && other.Contains(int_pt),
+                      "intersect forrreal (from mid)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
       }
 
       //      just one point in the the first extremity, going down
-      other = Line3D.FromPoints_NoThrow(p0 - 2 * u_perp, p0, default_precision);
+      other = Line3D.FromPoints_NoThrow(p0 - 2 * u_perp, p0);
       if (other != null) {
-        Assert.IsTrue(line.Intersects(other, default_precision),
-                      "intersect forrreal (to p0)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+        int_res = line.Intersection(other);
+        Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                      "intersect forrreal (to p0)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
+        int_pt = (Point3D)int_res.Value;
+        Assert.IsTrue(line.Contains(int_pt) && other.Contains(int_pt),
+                      "intersect forrreal (to p0)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
       }
 
       //      just one point in the the first extremity, going up
-      other = Line3D.FromPoints_NoThrow(p0 + 2 * u_perp, p0, default_precision);
+      other = Line3D.FromPoints_NoThrow(p0 + 2 * u_perp, p0);
       if (other != null) {
-        Assert.IsTrue(line.Intersects(other, default_precision),
-                      "intersect forrreal (from p0)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+        int_res = line.Intersection(other);
+        Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                      "intersect forrreal (from p0)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
+        int_pt = (Point3D)int_res.Value;
+        Assert.IsTrue(line.Contains(int_pt) && other.Contains(int_pt),
+                      "intersect forrreal (from p0)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
       }
 
       //      just one point in the the second extremity, going up
-      other = Line3D.FromPoints_NoThrow(p1, p1 + 2 * u_perp, default_precision);
+      other = Line3D.FromPoints_NoThrow(p1, p1 + 2 * u_perp);
       if (other != null) {
-        Assert.IsTrue(line.Intersects(other, default_precision),
-                      "intersect forrreal (from p1)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+        int_res = line.Intersection(other);
+        Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                      "intersect forrreal (from p1)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
+        int_pt = (Point3D)int_res.Value;
+        Assert.IsTrue(line.Contains(int_pt) && other.Contains(int_pt),
+                      "intersect forrreal (from p1)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
       }
 
       //      just one point in the the second extremity, going down
-      other = Line3D.FromPoints_NoThrow(p1, p1 - 2 * u_perp, default_precision);
+      other = Line3D.FromPoints_NoThrow(p1, p1 - 2 * u_perp);
       if (other != null) {
-        Assert.IsTrue(line.Intersects(other, default_precision),
-                      "intersect forrreal (to p1)" + "\n\tl1=" + line.ToWkt() + "\n\tl2=" + other.ToWkt());
+        int_res = line.Intersection(other);
+        Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                      "intersect forrreal (to p1)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
+        int_pt = (Point3D)int_res.Value;
+        Assert.IsTrue(line.Contains(int_pt) && other.Contains(int_pt),
+                      "intersect forrreal (to p1)" + "\nl1=" + line.ToWkt() + ", l2=" + other.ToWkt());
       }
 
       // case 2: no intersection (parallel, shift random vector)
       //      upwards
       Vector3D shift = RandomGenerator.MakeVector3D();
-      other = Line3D.FromPoints_NoThrow(p0 + 2 * shift, p1 + 2 * shift, default_precision);
+      other = Line3D.FromPoints_NoThrow(p0 + 2 * shift, p1 + 2 * shift);
       if (other != null) {
-        Assert.IsFalse(line.Intersects(other, default_precision),
-                       "no intersection (parallel, shift upwards random vector)" + "\n\tl1=" + line.ToWkt() +
-                           "\n\tl2=" + other.ToWkt());
+        int_res = line.Intersection(other);
+        Assert.IsTrue(int_res.ValueType == typeof(NullValue),
+                      "no intersection (parallel, shift upwards random vector)" + "\nl1=" + line.ToWkt() +
+                          ", l2=" + other.ToWkt());
       }
 
       //      downwards
-      other = Line3D.FromPoints_NoThrow(p0 - 2 * shift, p1 - 2 * shift, default_precision);
+      other = Line3D.FromPoints_NoThrow(p0 - 2 * shift, p1 - 2 * shift);
       if (other != null) {
-        Assert.IsFalse(line.Intersects(other, default_precision),
-                       "no intersection (parallel, shift downwards random vector)" + "\n\tl1=" + line.ToWkt() +
-                           "\n\tl2=" + other.ToWkt());
+        int_res = line.Intersection(other);
+        Assert.IsTrue(int_res.ValueType == typeof(NullValue),
+                      "no intersection (parallel, shift downwards random vector)" + "\nl1=" + line.ToWkt() +
+                          ", l2=" + other.ToWkt());
       }
     }
 

--- a/GeomSharpTests/LineSegment2DTests.cs
+++ b/GeomSharpTests/LineSegment2DTests.cs
@@ -64,64 +64,106 @@ namespace GeomSharpTests {
       // temp data
       LineSegment2D other;
       Vector2D u_perp = u.Perp();
+      IntersectionResult int_res = null;
+      Point2D int_pt = null;
 
       // case 1: intersect forrreal
       //      in the middle, crossing
       other = LineSegment2D.FromPoints(mid - 2 * u_perp, mid + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      on the first extremity, crossing
       other = LineSegment2D.FromPoints(p0 - 2 * u_perp, p0 + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other), "intersect forrreal (p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
+                    "intersect forrreal (p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      on the second extremity, crossing
       other = LineSegment2D.FromPoints(p1 - 2 * u_perp, p1 + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other), "intersect forrreal (p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
+                    "intersect forrreal (p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the middle, going down
       other = LineSegment2D.FromPoints(mid - 2 * u_perp, mid);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (to mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (to mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the middle, going up
       other = LineSegment2D.FromPoints(mid, mid + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the the first extremity, going down
       other = LineSegment2D.FromPoints(p0 - 2 * u_perp, p0);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (to p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (to p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the the first extremity, going up
       other = LineSegment2D.FromPoints(p0 + 2 * u_perp, p0);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the the second extremity, going up
       other = LineSegment2D.FromPoints(p1, p1 + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the the second extremity, going down
       other = LineSegment2D.FromPoints(p1, p1 - 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (to p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (to p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       // case 2: no intersection (parallel, shift random vector)
       //      upwards
       Vector2D shift = RandomGenerator.MakeVector2D();
       other = LineSegment2D.FromPoints(p0 + 2 * shift, p1 + 2 * shift);
-      Assert.IsFalse(
-          seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(
+          int_res.ValueType == typeof(NullValue),
           "no intersection (parallel, shift upwards random vector)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      downwards
       other = LineSegment2D.FromPoints(p0 - 2 * shift, p1 - 2 * shift);
-      Assert.IsFalse(seg.Intersects(other),
-                     "no intersection (parallel, shift downwards random vector)" + "\ns1=" + seg.ToWkt() +
-                         ", s2=" + other.ToWkt());
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType == typeof(NullValue),
+                    "no intersection (parallel, shift downwards random vector)" + "\ns1=" + seg.ToWkt() +
+                        ", s2=" + other.ToWkt());
     }
 
     [RepeatedTestMethod(100)]

--- a/GeomSharpTests/LineSegment3DTests.cs
+++ b/GeomSharpTests/LineSegment3DTests.cs
@@ -66,64 +66,106 @@ namespace GeomSharpTests {
       // temp data
       LineSegment3D other;
       Vector3D u_perp = u.CrossProduct((u.IsParallel(Vector3D.AxisZ) ? Vector3D.AxisY : Vector3D.AxisZ));
+      IntersectionResult int_res = null;
+      Point3D int_pt = null;
 
       // case 1: intersect forrreal
       //      in the middle, crossing
       other = LineSegment3D.FromPoints(mid - 2 * u_perp, mid + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      on the first extremity, crossing
       other = LineSegment3D.FromPoints(p0 - 2 * u_perp, p0 + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other), "intersect forrreal (p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
+                    "intersect forrreal (p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      on the second extremity, crossing
       other = LineSegment3D.FromPoints(p1 - 2 * u_perp, p1 + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other), "intersect forrreal (p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
+                    "intersect forrreal (p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the middle, going down
       other = LineSegment3D.FromPoints(mid - 2 * u_perp, mid);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (to mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (to mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the middle, going up
       other = LineSegment3D.FromPoints(mid, mid + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from mid)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the the first extremity, going down
       other = LineSegment3D.FromPoints(p0 - 2 * u_perp, p0);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (to p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (to p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the the first extremity, going up
       other = LineSegment3D.FromPoints(p0 + 2 * u_perp, p0);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from p0)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the the second extremity, going up
       other = LineSegment3D.FromPoints(p1, p1 + 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      just one point in the the second extremity, going down
       other = LineSegment3D.FromPoints(p1, p1 - 2 * u_perp);
-      Assert.IsTrue(seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (to p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(seg.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (to p1)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       // case 2: no intersection (parallel, shift random vector)
       //      upwards
       Vector3D shift = RandomGenerator.MakeVector3D();
       other = LineSegment3D.FromPoints(p0 + 2 * shift, p1 + 2 * shift);
-      Assert.IsFalse(
-          seg.Intersects(other),
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(
+          int_res.ValueType == typeof(NullValue),
           "no intersection (parallel, shift upwards random vector)" + "\ns1=" + seg.ToWkt() + ", s2=" + other.ToWkt());
 
       //      downwards
       other = LineSegment3D.FromPoints(p0 - 2 * shift, p1 - 2 * shift);
-      Assert.IsFalse(seg.Intersects(other),
-                     "no intersection (parallel, shift downwards random vector)" + "\ns1=" + seg.ToWkt() +
-                         ", s2=" + other.ToWkt());
+      int_res = seg.Intersection(other);
+      Assert.IsTrue(int_res.ValueType == typeof(NullValue),
+                    "no intersection (parallel, shift downwards random vector)" + "\ns1=" + seg.ToWkt() +
+                        ", s2=" + other.ToWkt());
     }
 
     [RepeatedTestMethod(100)]

--- a/GeomSharpTests/Ray2DTests.cs
+++ b/GeomSharpTests/Ray2DTests.cs
@@ -71,53 +71,91 @@ namespace GeomSharpTests {
       Ray2D other;
       Vector2D u_perp = u.Perp();
       UnitVector2D u_perp_norm = u_perp.Normalize();
+      IntersectionResult int_res = null;
+      Point2D int_pt = null;
 
       // case 1: intersect forrreal
       //      in the middle, crossing
       other = new Ray2D(mid + u_perp, -u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
                     "intersect forrreal (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
+                    "intersect forrreal (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+
       //      in the middle, crossing
       other = new Ray2D(mid - u_perp, u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
-                    "intersect forrreal (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (-mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
+                    "intersect forrreal (-mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      in the middle no intersection (shooting the other way)
       other = new Ray2D(mid + u_perp, u_perp_norm);
-      Assert.IsFalse(ray.Intersects(other),
-                     "no intersect (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType == typeof(NullValue),
+                    "no intersect (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      in the middle no intersection (shooting the other way)
       other = new Ray2D(mid - u_perp, -u_perp_norm);
-      Assert.IsFalse(ray.Intersects(other),
-                     "no intersect (-mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType == typeof(NullValue),
+                    "no intersect (-mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      on the first extremity, crossing
       other = new Ray2D(p0 + u_perp, -u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
                     "intersect forrreal (+p0)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
+                    "intersect forrreal (+p0)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+
       other = new Ray2D(p0 - u_perp, u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (-p0)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (-p0)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      just one point in the middle, going down
       other = new Ray2D(mid, -u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (to mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (to mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      just one point in the middle, going up
       other = new Ray2D(mid, u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      just one point in the the first extremity, going down
       other = new Ray2D(p0, u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from p0+)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from p0+)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      just one point in the the first extremity, going up
       other = new Ray2D(p0, -u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from p0-)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point2D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from p0-)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       // case 2: no intersection (parallel, shift random vector)
@@ -125,15 +163,17 @@ namespace GeomSharpTests {
       Vector2D shift = RandomGenerator.MakeVector2D();
       if (Math.Round(shift.Length(), Constants.NINE_DECIMALS) != 0) {
         other = new Ray2D(p0 + shift, u);
-        Assert.IsFalse(ray.Intersects(other),
-                       "no intersection (parallel, shift upwards random vector)" + "\nray1=" + ray.ToWkt() +
-                           ", ray2=" + other.ToWkt());
+        int_res = ray.Intersection(other);
+        Assert.IsTrue(int_res.ValueType == typeof(NullValue),
+                      "no intersection (parallel, shift upwards random vector)" + "\nray1=" + ray.ToWkt() +
+                          ", ray2=" + other.ToWkt());
 
         //      downwards
         other = new Ray2D(p0 - shift, u);
-        Assert.IsFalse(ray.Intersects(other),
-                       "no intersection (parallel, shift downwards random vector)" + "\nray1=" + ray.ToWkt() +
-                           ", ray2=" + other.ToWkt());
+        int_res = ray.Intersection(other);
+        Assert.IsTrue(int_res.ValueType == typeof(NullValue),
+                      "no intersection (parallel, shift downwards random vector)" + "\nray1=" + ray.ToWkt() +
+                          ", ray2=" + other.ToWkt());
       }
     }
 

--- a/GeomSharpTests/Ray3DTests.cs
+++ b/GeomSharpTests/Ray3DTests.cs
@@ -13,6 +13,8 @@ namespace GeomSharpTests {
   public class Ray3DTests {
     [RepeatedTestMethod(100)]
     public void Containment() {
+      int default_precision = Constants.THREE_DECIMALS;
+
       // input
       (var ray, var p0, var p1) = RandomGenerator.MakeRay3D();
 
@@ -23,42 +25,49 @@ namespace GeomSharpTests {
       // temp data
       Point3D p;
       UnitVector3D u = ray.Direction;
-      UnitVector3D u_perp =
-          u.CrossProduct((u.IsParallel(Vector3D.AxisZ) ? Vector3D.AxisY : Vector3D.AxisZ)).Normalize();
+      UnitVector3D u_perp = u.Perp().Normalize();
 
       // must contains the ray points (origin and p1)
       p = p0;
-      Assert.IsTrue(ray.Contains(p), "contains" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
+      Assert.IsTrue(ray.Contains(p, default_precision), "contains" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
 
       p = p1;
-      Assert.IsTrue(ray.Contains(p), "contains" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
+      Assert.IsTrue(ray.Contains(p, default_precision), "contains" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
 
       // does not contain points aside the ray
       p = p0 + u_perp;
-      Assert.IsFalse(ray.Contains(p), "point aside" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
+      Assert.IsFalse(ray.Contains(p, default_precision),
+                     "point aside" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
 
       p = p0 - u_perp;
-      Assert.IsFalse(ray.Contains(p), "point aside" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
+      Assert.IsFalse(ray.Contains(p, default_precision),
+                     "point aside" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
 
       p = p1 + u_perp;
-      Assert.IsFalse(ray.Contains(p), "point aside" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
+      Assert.IsFalse(ray.Contains(p, default_precision),
+                     "point aside" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
 
       p = p1 - u_perp;
-      Assert.IsFalse(ray.Contains(p), "point aside" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
+      Assert.IsFalse(ray.Contains(p, default_precision),
+                     "point aside" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
 
       // does not contain a point behind the ray
       p = p0 - 2 * u;
-      Assert.IsFalse(ray.Contains(p), "point behind" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
+      Assert.IsFalse(ray.Contains(p, default_precision),
+                     "point behind" + "\n\tray=" + ray.ToWkt() + "\n\tp=" + p.ToWkt());
 
       p = p0 - 2 * u - u_perp;
-      Assert.IsFalse(ray.Contains(p), "point behind right, ray=" + ray.ToWkt() + ", p=" + p.ToWkt());
+      Assert.IsFalse(ray.Contains(p, default_precision), "point behind right, ray=" + ray.ToWkt() + ", p=" + p.ToWkt());
 
       p = p0 - 2 * u + u_perp;
-      Assert.IsFalse(ray.Contains(p), "point behind left, ray=" + ray.ToWkt() + ", p=" + p.ToWkt());
+      Assert.IsFalse(ray.Contains(p, default_precision), "point behind left, ray=" + ray.ToWkt() + ", p=" + p.ToWkt());
     }
 
     [RepeatedTestMethod(100)]
     public void Intersection() {
+      // default precision
+      int default_precision = Constants.THREE_DECIMALS;
+
       // input
       (var ray, var p0, var p1) = RandomGenerator.MakeRay3D();
 
@@ -75,50 +84,50 @@ namespace GeomSharpTests {
 
       // case 1: intersect forrreal
       //      in the middle, crossing
-      other = new Ray3D(mid + 2 * u_perp, -u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      other = new Ray3D(mid + u_perp, -u_perp_norm);
+      Assert.IsTrue(ray.Intersects(other, default_precision),
                     "intersect forrreal (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
       //      in the middle, crossing
-      other = new Ray3D(mid - 2 * u_perp, u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      other = new Ray3D(mid - u_perp, u_perp_norm);
+      Assert.IsTrue(ray.Intersects(other, default_precision),
                     "intersect forrreal (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      in the middle no intersection (shooting the other way)
-      other = new Ray3D(mid + 2 * u_perp, u_perp_norm);
-      Assert.IsFalse(ray.Intersects(other),
+      other = new Ray3D(mid + u_perp, u_perp_norm);
+      Assert.IsFalse(ray.Intersects(other, default_precision),
                      "no intersect (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      in the middle no intersection (shooting the other way)
-      other = new Ray3D(mid - 2 * u_perp, -u_perp_norm);
-      Assert.IsFalse(ray.Intersects(other),
+      other = new Ray3D(mid - u_perp, -u_perp_norm);
+      Assert.IsFalse(ray.Intersects(other, default_precision),
                      "no intersect (-mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      on the first extremity, crossing
       other = new Ray3D(p0 + u_perp, -u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      Assert.IsTrue(ray.Intersects(other, default_precision),
                     "intersect forrreal (+p0)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
       other = new Ray3D(p0 - u_perp, u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      Assert.IsTrue(ray.Intersects(other, default_precision),
                     "intersect forrreal (-p0)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      just one point in the middle, going down
       other = new Ray3D(mid, -u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      Assert.IsTrue(ray.Intersects(other, default_precision),
                     "intersect forrreal (to mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      just one point in the middle, going up
       other = new Ray3D(mid, u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      Assert.IsTrue(ray.Intersects(other, default_precision),
                     "intersect forrreal (from mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      just one point in the the first extremity, going down
       other = new Ray3D(p0, u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      Assert.IsTrue(ray.Intersects(other, default_precision),
                     "intersect forrreal (from p0+)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      just one point in the the first extremity, going up
       other = new Ray3D(p0, -u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other),
+      Assert.IsTrue(ray.Intersects(other, default_precision),
                     "intersect forrreal (from p0-)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       // case 2: no intersection (parallel, shift random vector)
@@ -126,13 +135,13 @@ namespace GeomSharpTests {
       Vector3D shift = RandomGenerator.MakeVector3D();
       if (Math.Round(shift.Length(), Constants.NINE_DECIMALS) == 0) {
         other = new Ray3D(p0 + shift, u);
-        Assert.IsFalse(ray.Intersects(other),
+        Assert.IsFalse(ray.Intersects(other, default_precision),
                        "no intersection (parallel, shift upwards random vector)" + "\nray1=" + ray.ToWkt() +
                            ", ray2=" + other.ToWkt());
 
         //      downwards
         other = new Ray3D(p0 - shift, u);
-        Assert.IsFalse(ray.Intersects(other),
+        Assert.IsFalse(ray.Intersects(other, default_precision),
                        "no intersection (parallel, shift downwards random vector)" + "\nray1=" + ray.ToWkt() +
                            ", ray2=" + other.ToWkt());
       }
@@ -140,6 +149,8 @@ namespace GeomSharpTests {
 
     [RepeatedTestMethod(100)]
     public void Overlap() {
+      int default_precision = Constants.THREE_DECIMALS;
+
       // input
       (var ray, var p0, var p1) = RandomGenerator.MakeRay3D();
 
@@ -151,33 +162,34 @@ namespace GeomSharpTests {
 
       // temp data
       Ray3D other;
-      Vector3D u_perp = u.CrossProduct((u.IsParallel(Vector3D.AxisZ) ? Vector3D.AxisY : Vector3D.AxisZ));
+      Vector3D u_perp = u.Perp();
       UnitVector3D u_perp_norm = u_perp.Normalize();
 
       // case 1: overlap start point
       //      not insersect but overlap
       other = new Ray3D(p0 + 2 * u, u);
-      Assert.IsFalse(ray.Intersects(other),
+      Assert.IsFalse(ray.Intersects(other, default_precision),
                      "overlap start point" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
       Assert.IsTrue(ray.Overlaps(other), "overlap start point" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       // case 2: overlap end point
       //      not insersect but overlap
       other = new Ray3D(p0 - 2 * u, u);
-      Assert.IsFalse(ray.Intersects(other), "overlap end point" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      Assert.IsFalse(ray.Intersects(other, default_precision),
+                     "overlap end point" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
       Assert.IsTrue(ray.Overlaps(other), "overlap end point" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       // case 3: overlap both (first segment contained in the second)
       //      not insersect but overlap
       other = new Ray3D(p0 + u, -u);
       Assert.IsFalse(
-          ray.Intersects(other),
+          ray.Intersects(other, default_precision),
           "overlap both (first segment contained in the second)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
       Assert.IsTrue(
           ray.Overlaps(other),
           "overlap both (first segment contained in the second)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
       Assert.AreEqual(
-          ray.Overlap(other).ValueType,
+          ray.Overlap(other, default_precision).ValueType,
           typeof(LineSegment3D),
           "overlap both (first segment contained in the second)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
     }

--- a/GeomSharpTests/Ray3DTests.cs
+++ b/GeomSharpTests/Ray3DTests.cs
@@ -65,9 +65,6 @@ namespace GeomSharpTests {
 
     [RepeatedTestMethod(100)]
     public void Intersection() {
-      // default precision
-      int default_precision = Constants.THREE_DECIMALS;
-
       // input
       (var ray, var p0, var p1) = RandomGenerator.MakeRay3D();
 
@@ -81,53 +78,91 @@ namespace GeomSharpTests {
       Ray3D other;
       Vector3D u_perp = u.Perp();
       UnitVector3D u_perp_norm = u_perp.Normalize();
+      IntersectionResult int_res = null;
+      Point3D int_pt = null;
 
       // case 1: intersect forrreal
       //      in the middle, crossing
       other = new Ray3D(mid + u_perp, -u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other, default_precision),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
                     "intersect forrreal (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
+                    "intersect forrreal (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+
       //      in the middle, crossing
       other = new Ray3D(mid - u_perp, u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other, default_precision),
-                    "intersect forrreal (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (-mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
+                    "intersect forrreal (-mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      in the middle no intersection (shooting the other way)
       other = new Ray3D(mid + u_perp, u_perp_norm);
-      Assert.IsFalse(ray.Intersects(other, default_precision),
-                     "no intersect (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType == typeof(NullValue),
+                    "no intersect (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      in the middle no intersection (shooting the other way)
       other = new Ray3D(mid - u_perp, -u_perp_norm);
-      Assert.IsFalse(ray.Intersects(other, default_precision),
-                     "no intersect (-mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType == typeof(NullValue),
+                    "no intersect (-mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      on the first extremity, crossing
       other = new Ray3D(p0 + u_perp, -u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other, default_precision),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
                     "intersect forrreal (+p0)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
+                    "intersect forrreal (+p0)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+
       other = new Ray3D(p0 - u_perp, u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other, default_precision),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (-p0)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (-p0)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      just one point in the middle, going down
       other = new Ray3D(mid, -u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other, default_precision),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (to mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (to mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      just one point in the middle, going up
       other = new Ray3D(mid, u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other, default_precision),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      just one point in the the first extremity, going down
       other = new Ray3D(p0, u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other, default_precision),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from p0+)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from p0+)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      just one point in the the first extremity, going up
       other = new Ray3D(p0, -u_perp_norm);
-      Assert.IsTrue(ray.Intersects(other, default_precision),
+      int_res = ray.Intersection(other);
+      Assert.IsTrue(int_res.ValueType != typeof(NullValue),
+                    "intersect forrreal (from p0-)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
+      int_pt = (Point3D)int_res.Value;
+      Assert.IsTrue(ray.Contains(int_pt) && other.Contains(int_pt),
                     "intersect forrreal (from p0-)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       // case 2: no intersection (parallel, shift random vector)
@@ -135,15 +170,17 @@ namespace GeomSharpTests {
       Vector3D shift = RandomGenerator.MakeVector3D();
       if (Math.Round(shift.Length(), Constants.NINE_DECIMALS) == 0) {
         other = new Ray3D(p0 + shift, u);
-        Assert.IsFalse(ray.Intersects(other, default_precision),
-                       "no intersection (parallel, shift upwards random vector)" + "\nray1=" + ray.ToWkt() +
-                           ", ray2=" + other.ToWkt());
+        int_res = ray.Intersection(other);
+        Assert.IsTrue(int_res.ValueType == typeof(NullValue),
+                      "no intersection (parallel, shift upwards random vector)" + "\nray1=" + ray.ToWkt() +
+                          ", ray2=" + other.ToWkt());
 
         //      downwards
         other = new Ray3D(p0 - shift, u);
-        Assert.IsFalse(ray.Intersects(other, default_precision),
-                       "no intersection (parallel, shift downwards random vector)" + "\nray1=" + ray.ToWkt() +
-                           ", ray2=" + other.ToWkt());
+        int_res = ray.Intersection(other);
+        Assert.IsTrue(int_res.ValueType == typeof(NullValue),
+                      "no intersection (parallel, shift downwards random vector)" + "\nray1=" + ray.ToWkt() +
+                          ", ray2=" + other.ToWkt());
       }
     }
 

--- a/GeomSharpTests/Ray3DTests.cs
+++ b/GeomSharpTests/Ray3DTests.cs
@@ -70,26 +70,26 @@ namespace GeomSharpTests {
 
       // temp data
       Ray3D other;
-      Vector3D u_perp = u.CrossProduct((u.IsParallel(Vector3D.AxisZ) ? Vector3D.AxisY : Vector3D.AxisZ));
+      Vector3D u_perp = u.Perp();
       UnitVector3D u_perp_norm = u_perp.Normalize();
 
       // case 1: intersect forrreal
       //      in the middle, crossing
-      other = new Ray3D(mid + u_perp, -u_perp_norm);
+      other = new Ray3D(mid + 2 * u_perp, -u_perp_norm);
       Assert.IsTrue(ray.Intersects(other),
                     "intersect forrreal (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
       //      in the middle, crossing
-      other = new Ray3D(mid - u_perp, u_perp_norm);
+      other = new Ray3D(mid - 2 * u_perp, u_perp_norm);
       Assert.IsTrue(ray.Intersects(other),
                     "intersect forrreal (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      in the middle no intersection (shooting the other way)
-      other = new Ray3D(mid + u_perp, u_perp_norm);
+      other = new Ray3D(mid + 2 * u_perp, u_perp_norm);
       Assert.IsFalse(ray.Intersects(other),
                      "no intersect (+mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 
       //      in the middle no intersection (shooting the other way)
-      other = new Ray3D(mid - u_perp, -u_perp_norm);
+      other = new Ray3D(mid - 2 * u_perp, -u_perp_norm);
       Assert.IsFalse(ray.Intersects(other),
                      "no intersect (-mid)" + "\nray1=" + ray.ToWkt() + ", ray2=" + other.ToWkt());
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # GeomSharp
 
+
  A 2D (and 3D) geometry library for C#, based on .Net Framework 4.8
 
 


### PR DESCRIPTION
`LineSegment3D.Intersection()` formula was wrong. this PR fixes it. 
it also fixes some missing features (missing `decimal_precision` arguments from functions, bad tests ... ) 